### PR TITLE
Use public shroud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@
 source "https://rubygems.org"
 
 gem 'danger'
-gem 'danger-shroud', git: 'https://github.com/livefront/livefront-shroud-android/'
+gem 'danger-shroud'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/livefront/livefront-shroud-android/
-  revision: 1e0185efdd8e99c003e9a41bf0114dd826e1638c
-  specs:
-    danger-shroud (0.0.1)
-      danger-plugin-api (~> 1.0)
-      nokogiri
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -19,14 +11,14 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (6.3.1)
+    danger (8.0.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
-      faraday (~> 0.9)
+      faraday (>= 0.9.0, < 2.0)
       faraday-http-cache (~> 2.0)
-      git (~> 1.6)
+      git (~> 1.7)
       kramdown (~> 2.0)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
@@ -34,13 +26,17 @@ GEM
       terminal-table (~> 1)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    faraday (0.17.3)
+    danger-shroud (0.0.3)
+      danger-plugin-api (~> 1.0)
+      nokogiri
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (2.0.0)
-      faraday (~> 0.8)
-    git (1.6.0)
+    faraday-http-cache (2.2.0)
+      faraday (>= 0.8)
+    git (1.7.0)
       rchardet (~> 1.8)
-    kramdown (2.1.0)
+    kramdown (2.2.1)
+      rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     mini_portile2 (2.4.0)
@@ -49,25 +45,26 @@ GEM
     no_proxy_fix (0.1.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.16.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    public_suffix (4.0.3)
+    public_suffix (4.0.5)
     rchardet (1.8.0)
+    rexml (3.2.4)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   danger
-  danger-shroud!
+  danger-shroud
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
This PR lets the project use the public version of shroud (thanks @AndrewHaisting!) and also updates the ruby dependencies.