### PR TITLE
Add javadoc and source jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,13 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.livefront.sealed-enum:sealedenum:0.1.0")
-    kapt("com.github.livefront.sealed-enum:sealedenumprocessor:0.1.0")
+    implementation("com.github.livefront.sealed-enum:sealedenum:v0.1.0")
+    kapt("com.github.livefront.sealed-enum:sealedenumprocessor:v0.1.0")
 }
 ```
+
+### Class Documentation
+[Full class documentation for the runtime library is published automatically to JitPack](https://javadoc.jitpack.io/com/github/livefront/sealed-enum/sealedenum/latest/javadoc/sealedenum/index.html)
 
 ### License
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    kotlin("jvm") version "1.3.70"
+    kotlin("jvm") version "1.3.72"
     jacoco
     id("io.gitlab.arturbosch.detekt") version "1.6.0"
+    id("org.jetbrains.dokka") version "0.10.1"
+    `maven-publish`
 }
 
 allprojects {
@@ -17,7 +19,8 @@ subprojects {
         plugin<org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper>()
         plugin<JacocoPlugin>()
         plugin<io.gitlab.arturbosch.detekt.DetektPlugin>()
-        plugin<MavenPlugin>()
+        plugin<MavenPublishPlugin>()
+        plugin<org.jetbrains.dokka.gradle.DokkaPlugin>()
     }
 
     dependencies {
@@ -60,6 +63,35 @@ subprojects {
 
         withType<io.gitlab.arturbosch.detekt.Detekt> {
             jvmTarget = JavaVersion.VERSION_1_8.toString()
+        }
+
+        val dokka by getting(org.jetbrains.dokka.gradle.DokkaTask::class) {
+            outputFormat = "html"
+            outputDirectory = javadoc.get().destinationDir!!.absolutePath
+
+            configuration {
+                jdkVersion = 8
+            }
+        }
+
+        val sourcesJar by creating(Jar::class) {
+            archiveClassifier.set("sources")
+            from(sourceSets.main.get().allSource)
+        }
+
+        val javadocJar by creating(Jar::class) {
+            archiveClassifier.set("javadoc")
+            from(dokka)
+        }
+
+        publishing {
+            publications {
+                create<MavenPublication>("default") {
+                    from(this@subprojects.components["java"])
+                    artifact(sourcesJar)
+                    artifact(javadocJar)
+                }
+            }
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
This PR makes a couple version updates, to allow for publication of class documentation and source jar files.

The documentation for this branch can be seen here (https://javadoc.jitpack.io/com/github/livefront/sealed-enum/sealedenum/av~javadocAndSources-SNAPSHOT/javadoc/sealedenum/index.html), which is generated with Dokka.

The source code can also be viewed after importing this branches version of the library.