### PR TITLE
Create 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# 0.1.1
+Publish dokka documentation and sources
+
 # 0.1.0
 Initial preview release

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.livefront.sealed-enum:sealedenum:v0.1.0")
-    kapt("com.github.livefront.sealed-enum:sealedenumprocessor:v0.1.0")
+    implementation("com.github.livefront.sealed-enum:sealedenum:0.1.1")
+    kapt("com.github.livefront.sealed-enum:sealedenumprocessor:0.1.1")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 
 group=com.livefront.sealedenum
-version=0.1.0
+version=0.1.1


### PR DESCRIPTION
Updating the changelog, readme and `gradle.properties` with version `0.1.1`, which just bundles the dokka documentation and the sources.