### PR TITLE
Add handling for non-public visibility

### DIFF
--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/InvalidSubclassVisibilityException.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/InvalidSubclassVisibilityException.kt
@@ -1,0 +1,8 @@
+package com.livefront.sealedenum.internal
+
+import javax.lang.model.element.Element
+
+/**
+ * An exception that indicates that a sealed subclass has an invalid visibility.
+ */
+internal class InvalidSubclassVisibilityException(val element: Element) : Exception()

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/NonObjectSealedSubclassException.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/NonObjectSealedSubclassException.kt
@@ -1,6 +1,8 @@
 package com.livefront.sealedenum.internal
 
+import javax.lang.model.element.Element
+
 /**
  * An exception that indicates that sealed class has a non-object subclass.
  */
-internal class NonObjectSealedSubclassException : Exception()
+internal class NonObjectSealedSubclassException(val element: Element) : Exception()

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/SealedClassNode.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/SealedClassNode.kt
@@ -2,6 +2,7 @@ package com.livefront.sealedenum.internal
 
 import com.livefront.sealedenum.internal.SealedClassNode.Object
 import com.livefront.sealedenum.internal.SealedClassNode.SealedClass
+import com.livefront.sealedenum.internal.spec.SealedObject
 
 /**
  * An internal tree structure representing a sealed class and its sealed subclasses.

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/SealedEnumProcessor.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/SealedEnumProcessor.kt
@@ -3,8 +3,9 @@ package com.livefront.sealedenum.internal
 import com.google.auto.service.AutoService
 import com.livefront.sealedenum.GenSealedEnum
 import com.livefront.sealedenum.GenSealedEnums
-import com.livefront.sealedenum.internal.SealedEnumFileSpec.SealedEnumOption.SealedEnumOnly
-import com.livefront.sealedenum.internal.SealedEnumFileSpec.SealedEnumOption.SealedEnumWithEnum
+import com.livefront.sealedenum.internal.spec.SealedEnumFileSpec
+import com.livefront.sealedenum.internal.spec.SealedEnumFileSpec.SealedEnumOption.SealedEnumOnly
+import com.livefront.sealedenum.internal.spec.SealedEnumFileSpec.SealedEnumOption.SealedEnumWithEnum
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/Visibility.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/Visibility.kt
@@ -1,0 +1,12 @@
+package com.livefront.sealedenum.internal
+
+import com.squareup.kotlinpoet.KModifier
+
+/**
+ * A restricted enumeration of visibilities for use with sealed classes. Due to generating code that is in a different
+ * file, we can only reasonably work with sealed classes and companion objects that are public or internal.
+ */
+internal enum class Visibility(val kModifier: KModifier) {
+    PUBLIC(KModifier.PUBLIC),
+    INTERNAL(KModifier.INTERNAL);
+}

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/CamelCase.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/CamelCase.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 /**
  * Converts a PascalCase string to a camelCase string. That is, this function lowercases the first letter.

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/EnumForSealedEnumTypeSpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/EnumForSealedEnumTypeSpec.kt
@@ -1,5 +1,6 @@
 package com.livefront.sealedenum.internal.spec
 
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -10,14 +11,15 @@ import javax.lang.model.element.TypeElement
 /**
  * A builder for an enum class for the given [sealedClass].
  *
- * Given the [ClassName] of the [sealedClass], the [TypeElement] for the [sealedClassCompanionObjectElement], and the
- * list of [ClassName]s for the sealed subclasses, [build] will generate a [TypeSpec] for an enum class
+ * Given the [ClassName] of the [sealedClass], the [TypeElement] for the [sealedClassCompanionObjectElement], and
+ * the list of [ClassName]s for the sealed subclasses, [build] will generate a [TypeSpec] for an enum class.
  *
  * The name of the created enum class will be the name of the sealed class concatenated with [enumPrefix] concatenated
  * with "Enum".
  */
 internal data class EnumForSealedEnumTypeSpec(
     private val sealedClass: SealedClass,
+    private val sealedClassVisibility: Visibility,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedObjects: List<SealedObject>,
     private val parameterizedSealedClass: TypeName,
@@ -25,6 +27,7 @@ internal data class EnumForSealedEnumTypeSpec(
     private val sealedClassInterfaces: List<TypeName>
 ) {
     private val typeSpecBuilder = TypeSpec.enumBuilder(sealedClass.createEnumForSealedEnumName(enumPrefix))
+        .addModifiers(sealedClassVisibility.kModifier)
         .addOriginatingElement(sealedClassCompanionObjectElement)
         .addKdoc("An isomorphic enum for the sealed class [%T]", sealedClass)
         .primaryConstructor(

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/EnumForSealedEnumTypeSpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/EnumForSealedEnumTypeSpec.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/EnumSealedObjectPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/EnumSealedObjectPropertySpec.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
@@ -6,21 +6,21 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import javax.lang.model.element.TypeElement
 
-internal data class SealedEnumNamePropertySpec(
+internal data class EnumSealedObjectPropertySpec(
     private val sealedClass: SealedClass,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
-    private val enumPrefix: String
+    private val enumForSealedEnum: ClassName
 ) {
     fun build(): PropertySpec {
-        val propertySpecBuilder = PropertySpec.builder(pascalCaseToCamelCase(enumPrefix + "Name"), String::class)
+        val propertySpecBuilder = PropertySpec.builder("sealedObject", parameterizedSealedClass)
             .addOriginatingElement(sealedClassCompanionObjectElement)
-            .addKdoc("The name of [this] for use with valueOf.")
-            .receiver(parameterizedSealedClass)
+            .addKdoc("The isomorphic [%T] for [this].", sealedClass)
+            .receiver(enumForSealedEnum)
             .getter(
                 FunSpec.getterBuilder()
-                    .addStatement("return %T.nameOf(this)", sealedEnum)
+                    .addStatement("return %T.enumToSealedObject(this)", sealedEnum)
                     .build()
             )
 

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/EnumSealedObjectPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/EnumSealedObjectPropertySpec.kt
@@ -1,5 +1,6 @@
 package com.livefront.sealedenum.internal.spec
 
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
@@ -8,6 +9,7 @@ import javax.lang.model.element.TypeElement
 
 internal data class EnumSealedObjectPropertySpec(
     private val sealedClass: SealedClass,
+    private val sealedClassVisibility: Visibility,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
@@ -18,6 +20,7 @@ internal data class EnumSealedObjectPropertySpec(
             .addOriginatingElement(sealedClassCompanionObjectElement)
             .addKdoc("The isomorphic [%T] for [this].", sealedClass)
             .receiver(enumForSealedEnum)
+            .addModifiers(sealedClassVisibility.kModifier)
             .getter(
                 FunSpec.getterBuilder()
                     .addStatement("return %T.enumToSealedObject(this)", sealedEnum)

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedClassExtensions.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedClassExtensions.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.livefront.sealedenum.SealedEnum
 import com.squareup.kotlinpoet.ClassName

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumEnumPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumEnumPropertySpec.kt
@@ -1,5 +1,6 @@
 package com.livefront.sealedenum.internal.spec
 
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
@@ -8,6 +9,7 @@ import javax.lang.model.element.TypeElement
 
 internal data class SealedEnumEnumPropertySpec(
     private val sealedClass: SealedClass,
+    private val sealedClassVisibility: Visibility,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
@@ -19,6 +21,7 @@ internal data class SealedEnumEnumPropertySpec(
             .addOriginatingElement(sealedClassCompanionObjectElement)
             .addKdoc("The isomorphic [%T] for [this].", enumForSealedEnum)
             .receiver(parameterizedSealedClass)
+            .addModifiers(sealedClassVisibility.kModifier)
             .getter(
                 FunSpec.getterBuilder()
                     .addStatement("return %T.sealedObjectToEnum(this)", sealedEnum)

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumEnumPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumEnumPropertySpec.kt
@@ -1,31 +1,27 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
-import com.squareup.kotlinpoet.asClassName
 import javax.lang.model.element.TypeElement
 
-internal data class SealedEnumValuesPropertySpec(
+internal data class SealedEnumEnumPropertySpec(
     private val sealedClass: SealedClass,
     private val parameterizedSealedClass: TypeName,
-    private val sealedClassCompanionObject: ClassName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
+    private val enumForSealedEnum: ClassName,
     private val enumPrefix: String
 ) {
-    private val listOfSealedClass = List::class.asClassName().parameterizedBy(parameterizedSealedClass)
-
     fun build(): PropertySpec {
-        val propertySpecBuilder = PropertySpec.builder(pascalCaseToCamelCase(enumPrefix + "Values"), listOfSealedClass)
+        val propertySpecBuilder = PropertySpec.builder(pascalCaseToCamelCase(enumPrefix + "Enum"), enumForSealedEnum)
             .addOriginatingElement(sealedClassCompanionObjectElement)
-            .addKdoc("A list of all [%T] objects.", sealedClass)
-            .receiver(sealedClassCompanionObject)
+            .addKdoc("The isomorphic [%T] for [this].", enumForSealedEnum)
+            .receiver(parameterizedSealedClass)
             .getter(
                 FunSpec.getterBuilder()
-                    .addStatement("return %T.values", sealedEnum)
+                    .addStatement("return %T.sealedObjectToEnum(this)", sealedEnum)
                     .build()
             )
 

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumFileSpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumFileSpec.kt
@@ -1,7 +1,9 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.TreeTraversalOrder
+import com.livefront.sealedenum.internal.SealedClassNode
+import com.livefront.sealedenum.internal.getSealedObjectsFromNode
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumFileSpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumFileSpec.kt
@@ -3,6 +3,7 @@ package com.livefront.sealedenum.internal.spec
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.TreeTraversalOrder
 import com.livefront.sealedenum.internal.SealedClassNode
+import com.livefront.sealedenum.internal.Visibility
 import com.livefront.sealedenum.internal.getSealedObjectsFromNode
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
@@ -24,12 +25,27 @@ import javax.lang.model.element.TypeElement
  */
 internal data class SealedEnumFileSpec(
     private val sealedClass: ClassName,
+    private val sealedClassVisibility: Visibility,
     private val sealedClassCompanionObject: ClassName,
+    private val sealedClassCompanionObjectVisibility: Visibility,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedClassNode: SealedClassNode.SealedClass,
     private val typeParameters: List<TypeName>,
     private val sealedEnumOptions: Map<TreeTraversalOrder, SealedEnumOption>
 ) {
+
+    /**
+     * Determines the effective visibility of the companion object based on the companion object's visibility and the
+     * sealed class's visibility. If either are internal, than the effective visibility is internal.
+     */
+    private val sealedClassCompanionObjectEffectiveVisibility = when (sealedClassCompanionObjectVisibility) {
+        Visibility.PUBLIC -> when (sealedClassVisibility) {
+            Visibility.INTERNAL -> Visibility.INTERNAL
+            Visibility.PUBLIC -> Visibility.PUBLIC
+        }
+        Visibility.INTERNAL -> Visibility.INTERNAL
+    }
+
     fun build(): FileSpec {
         val fileName = "${sealedClass.simpleNames.joinToString(".")}_SealedEnum"
         val fileSpecBuilder = FileSpec.builder(sealedClass.packageName, fileName).indent("    ")
@@ -56,6 +72,7 @@ internal data class SealedEnumFileSpec(
 
             val sealedEnumTypeSpecBuilder = SealedEnumTypeSpec(
                 sealedClass = sealedClass,
+                sealedClassVisibility = sealedClassVisibility,
                 parameterizedSealedClass = parameterizedSealedClass,
                 sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
                 sealedObjects = sealedObjects,
@@ -103,6 +120,7 @@ internal data class SealedEnumFileSpec(
     ) {
         val enumForSealedEnumTypeSpec = EnumForSealedEnumTypeSpec(
             sealedClass = sealedClass,
+            sealedClassVisibility = sealedClassVisibility,
             parameterizedSealedClass = parameterizedSealedClass,
             sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
             sealedObjects = sealedObjects,
@@ -122,6 +140,7 @@ internal data class SealedEnumFileSpec(
         fileSpecBuilder.addProperty(
             SealedEnumEnumPropertySpec(
                 sealedClass = sealedClass,
+                sealedClassVisibility = sealedClassVisibility,
                 parameterizedSealedClass = parameterizedSealedClass,
                 sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
                 sealedEnum = sealedEnumClassName,
@@ -135,6 +154,7 @@ internal data class SealedEnumFileSpec(
         fileSpecBuilder.addProperty(
             EnumSealedObjectPropertySpec(
                 sealedClass = sealedClass,
+                sealedClassVisibility = sealedClassVisibility,
                 parameterizedSealedClass = parameterizedSealedClass,
                 sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
                 sealedEnum = sealedEnumClassName,
@@ -157,6 +177,7 @@ internal data class SealedEnumFileSpec(
         fileSpecBuilder.addProperty(
             SealedEnumOrdinalPropertySpec(
                 sealedClass = sealedClass,
+                sealedClassVisibility = sealedClassVisibility,
                 parameterizedSealedClass = parameterizedSealedClass,
                 sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
                 sealedEnum = sealedEnumClassName,
@@ -169,6 +190,7 @@ internal data class SealedEnumFileSpec(
         fileSpecBuilder.addProperty(
             SealedEnumNamePropertySpec(
                 sealedClass = sealedClass,
+                sealedClassVisibility = sealedClassVisibility,
                 parameterizedSealedClass = parameterizedSealedClass,
                 sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
                 sealedEnum = sealedEnumClassName,
@@ -183,6 +205,7 @@ internal data class SealedEnumFileSpec(
                 sealedClass = sealedClass,
                 parameterizedSealedClass = parameterizedSealedClass,
                 sealedClassCompanionObject = sealedClassCompanionObject,
+                sealedClassCompanionObjectEffectiveVisibility = sealedClassCompanionObjectEffectiveVisibility,
                 sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
                 sealedEnum = sealedEnumClassName,
                 enumPrefix = enumPrefix
@@ -195,6 +218,7 @@ internal data class SealedEnumFileSpec(
             SealedEnumSealedEnumPropertySpec(
                 sealedClass = sealedClass,
                 sealedClassCompanionObject = sealedClassCompanionObject,
+                sealedClassCompanionObjectEffectiveVisibility = sealedClassCompanionObjectEffectiveVisibility,
                 sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
                 sealedEnum = sealedEnumClassName,
                 enumPrefix = enumPrefix
@@ -208,6 +232,7 @@ internal data class SealedEnumFileSpec(
                 sealedClass = sealedClass,
                 parameterizedSealedClass = parameterizedSealedClass,
                 sealedClassCompanionObject = sealedClassCompanionObject,
+                sealedClassCompanionObjectEffectiveVisibility = sealedClassCompanionObjectEffectiveVisibility,
                 sealedClassCompanionObjectElement = sealedClassCompanionObjectElement,
                 sealedEnum = sealedEnumClassName,
                 enumPrefix = enumPrefix

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumNamePropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumNamePropertySpec.kt
@@ -1,5 +1,6 @@
 package com.livefront.sealedenum.internal.spec
 
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
@@ -8,6 +9,7 @@ import javax.lang.model.element.TypeElement
 
 internal data class SealedEnumNamePropertySpec(
     private val sealedClass: SealedClass,
+    private val sealedClassVisibility: Visibility,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
@@ -18,6 +20,7 @@ internal data class SealedEnumNamePropertySpec(
             .addOriginatingElement(sealedClassCompanionObjectElement)
             .addKdoc("The name of [this] for use with valueOf.")
             .receiver(parameterizedSealedClass)
+            .addModifiers(sealedClassVisibility.kModifier)
             .getter(
                 FunSpec.getterBuilder()
                     .addStatement("return %T.nameOf(this)", sealedEnum)

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumNamePropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumNamePropertySpec.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
@@ -6,22 +6,21 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import javax.lang.model.element.TypeElement
 
-internal data class SealedEnumEnumPropertySpec(
+internal data class SealedEnumNamePropertySpec(
     private val sealedClass: SealedClass,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
-    private val enumForSealedEnum: ClassName,
     private val enumPrefix: String
 ) {
     fun build(): PropertySpec {
-        val propertySpecBuilder = PropertySpec.builder(pascalCaseToCamelCase(enumPrefix + "Enum"), enumForSealedEnum)
+        val propertySpecBuilder = PropertySpec.builder(pascalCaseToCamelCase(enumPrefix + "Name"), String::class)
             .addOriginatingElement(sealedClassCompanionObjectElement)
-            .addKdoc("The isomorphic [%T] for [this].", enumForSealedEnum)
+            .addKdoc("The name of [this] for use with valueOf.")
             .receiver(parameterizedSealedClass)
             .getter(
                 FunSpec.getterBuilder()
-                    .addStatement("return %T.sealedObjectToEnum(this)", sealedEnum)
+                    .addStatement("return %T.nameOf(this)", sealedEnum)
                     .build()
             )
 

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumOrdinalPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumOrdinalPropertySpec.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
@@ -6,21 +6,21 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import javax.lang.model.element.TypeElement
 
-internal data class EnumSealedObjectPropertySpec(
+internal data class SealedEnumOrdinalPropertySpec(
     private val sealedClass: SealedClass,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
-    private val enumForSealedEnum: ClassName
+    private val enumPrefix: String
 ) {
     fun build(): PropertySpec {
-        val propertySpecBuilder = PropertySpec.builder("sealedObject", parameterizedSealedClass)
+        val propertySpecBuilder = PropertySpec.builder(pascalCaseToCamelCase(enumPrefix + "Ordinal"), Int::class)
             .addOriginatingElement(sealedClassCompanionObjectElement)
-            .addKdoc("The isomorphic [%T] for [this].", sealedClass)
-            .receiver(enumForSealedEnum)
+            .addKdoc("The index of [this] in the values list.")
+            .receiver(parameterizedSealedClass)
             .getter(
                 FunSpec.getterBuilder()
-                    .addStatement("return %T.enumToSealedObject(this)", sealedEnum)
+                    .addStatement("return %T.ordinalOf(this)", sealedEnum)
                     .build()
             )
 

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumOrdinalPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumOrdinalPropertySpec.kt
@@ -1,5 +1,6 @@
 package com.livefront.sealedenum.internal.spec
 
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
@@ -8,6 +9,7 @@ import javax.lang.model.element.TypeElement
 
 internal data class SealedEnumOrdinalPropertySpec(
     private val sealedClass: SealedClass,
+    private val sealedClassVisibility: Visibility,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
@@ -18,6 +20,7 @@ internal data class SealedEnumOrdinalPropertySpec(
             .addOriginatingElement(sealedClassCompanionObjectElement)
             .addKdoc("The index of [this] in the values list.")
             .receiver(parameterizedSealedClass)
+            .addModifiers(sealedClassVisibility.kModifier)
             .getter(
                 FunSpec.getterBuilder()
                     .addStatement("return %T.ordinalOf(this)", sealedEnum)

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumSealedEnumPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumSealedEnumPropertySpec.kt
@@ -1,6 +1,7 @@
 package com.livefront.sealedenum.internal.spec
 
 import com.livefront.sealedenum.SealedEnum
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
@@ -9,6 +10,7 @@ import javax.lang.model.element.TypeElement
 internal data class SealedEnumSealedEnumPropertySpec(
     private val sealedClass: SealedClass,
     private val sealedClassCompanionObject: ClassName,
+    private val sealedClassCompanionObjectEffectiveVisibility: Visibility,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
     private val enumPrefix: String
@@ -18,6 +20,7 @@ internal data class SealedEnumSealedEnumPropertySpec(
             .addOriginatingElement(sealedClassCompanionObjectElement)
             .addKdoc("Returns an implementation of [%T] for the sealed class [%T]", SealedEnum::class, sealedClass)
             .receiver(sealedClassCompanionObject)
+            .addModifiers(sealedClassCompanionObjectEffectiveVisibility.kModifier)
             .getter(
                 FunSpec.getterBuilder()
                     .addStatement("return %T", sealedEnum)

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumSealedEnumPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumSealedEnumPropertySpec.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.livefront.sealedenum.SealedEnum
 import com.squareup.kotlinpoet.ClassName

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumTypeSpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumTypeSpec.kt
@@ -3,6 +3,7 @@ package com.livefront.sealedenum.internal.spec
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
@@ -29,6 +30,7 @@ import javax.lang.model.element.TypeElement
  */
 internal data class SealedEnumTypeSpec(
     private val sealedClass: SealedClass,
+    private val sealedClassVisibility: Visibility,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedObjects: List<SealedObject>,
@@ -39,6 +41,7 @@ internal data class SealedEnumTypeSpec(
     private val sealedEnum = SealedEnum::class.asClassName()
     private val parameterizedSealedClassEnum = sealedEnum.parameterizedBy(parameterizedSealedClass)
     private val typeSpecBuilder = TypeSpec.objectBuilder(name)
+        .addModifiers(sealedClassVisibility.kModifier)
         .addSuperinterface(parameterizedSealedClassEnum)
         .addOriginatingElement(sealedClassCompanionObjectElement)
         .addKdoc("An implementation of [%T] for the sealed class [%T]", sealedEnum, sealedClass)

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumTypeSpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumTypeSpec.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumValueOfFunSpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumValueOfFunSpec.kt
@@ -1,4 +1,4 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumValueOfFunSpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumValueOfFunSpec.kt
@@ -1,5 +1,6 @@
 package com.livefront.sealedenum.internal.spec
 
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeName
@@ -9,6 +10,7 @@ internal data class SealedEnumValueOfFunSpec(
     private val sealedClass: SealedClass,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObject: ClassName,
+    private val sealedClassCompanionObjectEffectiveVisibility: Visibility,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
     private val enumPrefix: String
@@ -26,6 +28,7 @@ internal data class SealedEnumValueOfFunSpec(
                 sealedClass
             )
             .receiver(sealedClassCompanionObject)
+            .addModifiers(sealedClassCompanionObjectEffectiveVisibility.kModifier)
             .returns(parameterizedSealedClass)
             .addParameter("name", String::class)
             .addStatement("return %T.valueOf(name)", sealedEnum)

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumValuesPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumValuesPropertySpec.kt
@@ -1,26 +1,31 @@
-package com.livefront.sealedenum.internal
+package com.livefront.sealedenum.internal.spec
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.asClassName
 import javax.lang.model.element.TypeElement
 
-internal data class SealedEnumOrdinalPropertySpec(
+internal data class SealedEnumValuesPropertySpec(
     private val sealedClass: SealedClass,
     private val parameterizedSealedClass: TypeName,
+    private val sealedClassCompanionObject: ClassName,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
     private val enumPrefix: String
 ) {
+    private val listOfSealedClass = List::class.asClassName().parameterizedBy(parameterizedSealedClass)
+
     fun build(): PropertySpec {
-        val propertySpecBuilder = PropertySpec.builder(pascalCaseToCamelCase(enumPrefix + "Ordinal"), Int::class)
+        val propertySpecBuilder = PropertySpec.builder(pascalCaseToCamelCase(enumPrefix + "Values"), listOfSealedClass)
             .addOriginatingElement(sealedClassCompanionObjectElement)
-            .addKdoc("The index of [this] in the values list.")
-            .receiver(parameterizedSealedClass)
+            .addKdoc("A list of all [%T] objects.", sealedClass)
+            .receiver(sealedClassCompanionObject)
             .getter(
                 FunSpec.getterBuilder()
-                    .addStatement("return %T.ordinalOf(this)", sealedEnum)
+                    .addStatement("return %T.values", sealedEnum)
                     .build()
             )
 

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumValuesPropertySpec.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedEnumValuesPropertySpec.kt
@@ -1,5 +1,6 @@
 package com.livefront.sealedenum.internal.spec
 
+import com.livefront.sealedenum.internal.Visibility
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -12,6 +13,7 @@ internal data class SealedEnumValuesPropertySpec(
     private val sealedClass: SealedClass,
     private val parameterizedSealedClass: TypeName,
     private val sealedClassCompanionObject: ClassName,
+    private val sealedClassCompanionObjectEffectiveVisibility: Visibility,
     private val sealedClassCompanionObjectElement: TypeElement,
     private val sealedEnum: ClassName,
     private val enumPrefix: String
@@ -23,6 +25,7 @@ internal data class SealedEnumValuesPropertySpec(
             .addOriginatingElement(sealedClassCompanionObjectElement)
             .addKdoc("A list of all [%T] objects.", sealedClass)
             .receiver(sealedClassCompanionObject)
+            .addModifiers(sealedClassCompanionObjectEffectiveVisibility.kModifier)
             .getter(
                 FunSpec.getterBuilder()
                     .addStatement("return %T.values", sealedEnum)

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/VisibilitySealedClass.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/VisibilitySealedClass.kt
@@ -1,0 +1,516 @@
+package com.livefront.sealedenum
+
+import org.intellij.lang.annotations.Language
+
+sealed class InternalObjectsSealedClass {
+    internal object FirstObject : InternalObjectsSealedClass()
+
+    internal object SecondObject : InternalObjectsSealedClass()
+
+    internal sealed class InnerSealedClass : InternalObjectsSealedClass() {
+        internal object ThirdObject : InnerSealedClass()
+    }
+
+    @GenSealedEnum(generateEnum = true)
+    companion object
+}
+
+@Language("kotlin")
+val internalObjectsSealedClassGenerated = """
+package com.livefront.sealedenum
+
+import java.lang.Class
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+/**
+ * An isomorphic enum for the sealed class [InternalObjectsSealedClass]
+ */
+enum class InternalObjectsSealedClassEnum {
+    InternalObjectsSealedClass_FirstObject,
+
+    InternalObjectsSealedClass_SecondObject,
+
+    InternalObjectsSealedClass_InnerSealedClass_ThirdObject
+}
+
+/**
+ * The isomorphic [InternalObjectsSealedClassEnum] for [this].
+ */
+val InternalObjectsSealedClass.enum: InternalObjectsSealedClassEnum
+    get() = InternalObjectsSealedClassSealedEnum.sealedObjectToEnum(this)
+
+/**
+ * The isomorphic [InternalObjectsSealedClass] for [this].
+ */
+val InternalObjectsSealedClassEnum.sealedObject: InternalObjectsSealedClass
+    get() = InternalObjectsSealedClassSealedEnum.enumToSealedObject(this)
+
+/**
+ * An implementation of [SealedEnum] for the sealed class [InternalObjectsSealedClass]
+ */
+object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsSealedClass>,
+        SealedEnumWithEnumProvider<InternalObjectsSealedClass, InternalObjectsSealedClassEnum>,
+        EnumForSealedEnumProvider<InternalObjectsSealedClass, InternalObjectsSealedClassEnum> {
+    override val values: List<InternalObjectsSealedClass> = listOf(
+        InternalObjectsSealedClass.FirstObject,
+        InternalObjectsSealedClass.SecondObject,
+        InternalObjectsSealedClass.InnerSealedClass.ThirdObject
+    )
+
+
+    override val enumClass: Class<InternalObjectsSealedClassEnum>
+        get() = InternalObjectsSealedClassEnum::class.java
+
+    override fun ordinalOf(obj: InternalObjectsSealedClass): Int = when (obj) {
+        InternalObjectsSealedClass.FirstObject -> 0
+        InternalObjectsSealedClass.SecondObject -> 1
+        InternalObjectsSealedClass.InnerSealedClass.ThirdObject -> 2
+    }
+
+    override fun nameOf(obj: InternalObjectsSealedClass): String = when (obj) {
+        InternalObjectsSealedClass.FirstObject -> "InternalObjectsSealedClass_FirstObject"
+        InternalObjectsSealedClass.SecondObject -> "InternalObjectsSealedClass_SecondObject"
+        InternalObjectsSealedClass.InnerSealedClass.ThirdObject ->
+                "InternalObjectsSealedClass_InnerSealedClass_ThirdObject"
+    }
+
+    override fun valueOf(name: String): InternalObjectsSealedClass = when (name) {
+        "InternalObjectsSealedClass_FirstObject" -> InternalObjectsSealedClass.FirstObject
+        "InternalObjectsSealedClass_SecondObject" -> InternalObjectsSealedClass.SecondObject
+        "InternalObjectsSealedClass_InnerSealedClass_ThirdObject" ->
+                InternalObjectsSealedClass.InnerSealedClass.ThirdObject
+        else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
+    }
+
+    override fun sealedObjectToEnum(obj: InternalObjectsSealedClass): InternalObjectsSealedClassEnum
+            = when (obj) {
+        InternalObjectsSealedClass.FirstObject ->
+                InternalObjectsSealedClassEnum.InternalObjectsSealedClass_FirstObject
+        InternalObjectsSealedClass.SecondObject ->
+                InternalObjectsSealedClassEnum.InternalObjectsSealedClass_SecondObject
+        InternalObjectsSealedClass.InnerSealedClass.ThirdObject ->
+                InternalObjectsSealedClassEnum.InternalObjectsSealedClass_InnerSealedClass_ThirdObject
+    }
+
+    override fun enumToSealedObject(enum: InternalObjectsSealedClassEnum):
+            InternalObjectsSealedClass = when (enum) {
+        InternalObjectsSealedClassEnum.InternalObjectsSealedClass_FirstObject ->
+                InternalObjectsSealedClass.FirstObject
+        InternalObjectsSealedClassEnum.InternalObjectsSealedClass_SecondObject ->
+                InternalObjectsSealedClass.SecondObject
+        InternalObjectsSealedClassEnum.InternalObjectsSealedClass_InnerSealedClass_ThirdObject ->
+                InternalObjectsSealedClass.InnerSealedClass.ThirdObject
+    }
+}
+
+/**
+ * The index of [this] in the values list.
+ */
+val InternalObjectsSealedClass.ordinal: Int
+    get() = InternalObjectsSealedClassSealedEnum.ordinalOf(this)
+
+/**
+ * The name of [this] for use with valueOf.
+ */
+val InternalObjectsSealedClass.name: String
+    get() = InternalObjectsSealedClassSealedEnum.nameOf(this)
+
+/**
+ * A list of all [InternalObjectsSealedClass] objects.
+ */
+val InternalObjectsSealedClass.Companion.values: List<InternalObjectsSealedClass>
+    get() = InternalObjectsSealedClassSealedEnum.values
+
+/**
+ * Returns an implementation of [SealedEnum] for the sealed class [InternalObjectsSealedClass]
+ */
+val InternalObjectsSealedClass.Companion.sealedEnum: InternalObjectsSealedClassSealedEnum
+    get() = InternalObjectsSealedClassSealedEnum
+
+/**
+ * Returns the [InternalObjectsSealedClass] object for the given [name].
+ *
+ * If the given name doesn't correspond to any [InternalObjectsSealedClass], an
+ * [IllegalArgumentException] will be thrown.
+ */
+fun InternalObjectsSealedClass.Companion.valueOf(name: String): InternalObjectsSealedClass =
+        InternalObjectsSealedClassSealedEnum.valueOf(name)
+
+""".trimIndent()
+
+internal sealed class InternalSealedClass {
+    object FirstObject : InternalSealedClass()
+
+    internal object SecondObject : InternalSealedClass()
+
+    @GenSealedEnum(generateEnum = true)
+    companion object
+}
+
+@Language("kotlin")
+val internalSealedClassGenerated = """
+package com.livefront.sealedenum
+
+import java.lang.Class
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+/**
+ * An isomorphic enum for the sealed class [InternalSealedClass]
+ */
+internal enum class InternalSealedClassEnum {
+    InternalSealedClass_FirstObject,
+
+    InternalSealedClass_SecondObject
+}
+
+/**
+ * The isomorphic [InternalSealedClassEnum] for [this].
+ */
+internal val InternalSealedClass.enum: InternalSealedClassEnum
+    get() = InternalSealedClassSealedEnum.sealedObjectToEnum(this)
+
+/**
+ * The isomorphic [InternalSealedClass] for [this].
+ */
+internal val InternalSealedClassEnum.sealedObject: InternalSealedClass
+    get() = InternalSealedClassSealedEnum.enumToSealedObject(this)
+
+/**
+ * An implementation of [SealedEnum] for the sealed class [InternalSealedClass]
+ */
+internal object InternalSealedClassSealedEnum : SealedEnum<InternalSealedClass>,
+        SealedEnumWithEnumProvider<InternalSealedClass, InternalSealedClassEnum>,
+        EnumForSealedEnumProvider<InternalSealedClass, InternalSealedClassEnum> {
+    override val values: List<InternalSealedClass> = listOf(
+        InternalSealedClass.FirstObject,
+        InternalSealedClass.SecondObject
+    )
+
+
+    override val enumClass: Class<InternalSealedClassEnum>
+        get() = InternalSealedClassEnum::class.java
+
+    override fun ordinalOf(obj: InternalSealedClass): Int = when (obj) {
+        InternalSealedClass.FirstObject -> 0
+        InternalSealedClass.SecondObject -> 1
+    }
+
+    override fun nameOf(obj: InternalSealedClass): String = when (obj) {
+        InternalSealedClass.FirstObject -> "InternalSealedClass_FirstObject"
+        InternalSealedClass.SecondObject -> "InternalSealedClass_SecondObject"
+    }
+
+    override fun valueOf(name: String): InternalSealedClass = when (name) {
+        "InternalSealedClass_FirstObject" -> InternalSealedClass.FirstObject
+        "InternalSealedClass_SecondObject" -> InternalSealedClass.SecondObject
+        else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
+    }
+
+    override fun sealedObjectToEnum(obj: InternalSealedClass): InternalSealedClassEnum = when
+            (obj) {
+        InternalSealedClass.FirstObject -> InternalSealedClassEnum.InternalSealedClass_FirstObject
+        InternalSealedClass.SecondObject -> InternalSealedClassEnum.InternalSealedClass_SecondObject
+    }
+
+    override fun enumToSealedObject(enum: InternalSealedClassEnum): InternalSealedClass = when
+            (enum) {
+        InternalSealedClassEnum.InternalSealedClass_FirstObject -> InternalSealedClass.FirstObject
+        InternalSealedClassEnum.InternalSealedClass_SecondObject -> InternalSealedClass.SecondObject
+    }
+}
+
+/**
+ * The index of [this] in the values list.
+ */
+internal val InternalSealedClass.ordinal: Int
+    get() = InternalSealedClassSealedEnum.ordinalOf(this)
+
+/**
+ * The name of [this] for use with valueOf.
+ */
+internal val InternalSealedClass.name: String
+    get() = InternalSealedClassSealedEnum.nameOf(this)
+
+/**
+ * A list of all [InternalSealedClass] objects.
+ */
+internal val InternalSealedClass.Companion.values: List<InternalSealedClass>
+    get() = InternalSealedClassSealedEnum.values
+
+/**
+ * Returns an implementation of [SealedEnum] for the sealed class [InternalSealedClass]
+ */
+internal val InternalSealedClass.Companion.sealedEnum: InternalSealedClassSealedEnum
+    get() = InternalSealedClassSealedEnum
+
+/**
+ * Returns the [InternalSealedClass] object for the given [name].
+ *
+ * If the given name doesn't correspond to any [InternalSealedClass], an [IllegalArgumentException]
+ * will be thrown.
+ */
+internal fun InternalSealedClass.Companion.valueOf(name: String): InternalSealedClass =
+        InternalSealedClassSealedEnum.valueOf(name)
+
+""".trimIndent()
+
+sealed class InternalCompanionSealedClass {
+    object FirstObject : InternalCompanionSealedClass()
+
+    internal object SecondObject : InternalCompanionSealedClass()
+
+    @GenSealedEnum(generateEnum = true)
+    internal companion object
+}
+
+@Language("kotlin")
+val internalCompanionSealedClassGenerated = """
+package com.livefront.sealedenum
+
+import java.lang.Class
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+/**
+ * An isomorphic enum for the sealed class [InternalCompanionSealedClass]
+ */
+enum class InternalCompanionSealedClassEnum {
+    InternalCompanionSealedClass_FirstObject,
+
+    InternalCompanionSealedClass_SecondObject
+}
+
+/**
+ * The isomorphic [InternalCompanionSealedClassEnum] for [this].
+ */
+val InternalCompanionSealedClass.enum: InternalCompanionSealedClassEnum
+    get() = InternalCompanionSealedClassSealedEnum.sealedObjectToEnum(this)
+
+/**
+ * The isomorphic [InternalCompanionSealedClass] for [this].
+ */
+val InternalCompanionSealedClassEnum.sealedObject: InternalCompanionSealedClass
+    get() = InternalCompanionSealedClassSealedEnum.enumToSealedObject(this)
+
+/**
+ * An implementation of [SealedEnum] for the sealed class [InternalCompanionSealedClass]
+ */
+object InternalCompanionSealedClassSealedEnum : SealedEnum<InternalCompanionSealedClass>,
+        SealedEnumWithEnumProvider<InternalCompanionSealedClass, InternalCompanionSealedClassEnum>,
+        EnumForSealedEnumProvider<InternalCompanionSealedClass, InternalCompanionSealedClassEnum> {
+    override val values: List<InternalCompanionSealedClass> = listOf(
+        InternalCompanionSealedClass.FirstObject,
+        InternalCompanionSealedClass.SecondObject
+    )
+
+
+    override val enumClass: Class<InternalCompanionSealedClassEnum>
+        get() = InternalCompanionSealedClassEnum::class.java
+
+    override fun ordinalOf(obj: InternalCompanionSealedClass): Int = when (obj) {
+        InternalCompanionSealedClass.FirstObject -> 0
+        InternalCompanionSealedClass.SecondObject -> 1
+    }
+
+    override fun nameOf(obj: InternalCompanionSealedClass): String = when (obj) {
+        InternalCompanionSealedClass.FirstObject -> "InternalCompanionSealedClass_FirstObject"
+        InternalCompanionSealedClass.SecondObject -> "InternalCompanionSealedClass_SecondObject"
+    }
+
+    override fun valueOf(name: String): InternalCompanionSealedClass = when (name) {
+        "InternalCompanionSealedClass_FirstObject" -> InternalCompanionSealedClass.FirstObject
+        "InternalCompanionSealedClass_SecondObject" -> InternalCompanionSealedClass.SecondObject
+        else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
+    }
+
+    override fun sealedObjectToEnum(obj: InternalCompanionSealedClass):
+            InternalCompanionSealedClassEnum = when (obj) {
+        InternalCompanionSealedClass.FirstObject ->
+                InternalCompanionSealedClassEnum.InternalCompanionSealedClass_FirstObject
+        InternalCompanionSealedClass.SecondObject ->
+                InternalCompanionSealedClassEnum.InternalCompanionSealedClass_SecondObject
+    }
+
+    override fun enumToSealedObject(enum: InternalCompanionSealedClassEnum):
+            InternalCompanionSealedClass = when (enum) {
+        InternalCompanionSealedClassEnum.InternalCompanionSealedClass_FirstObject ->
+                InternalCompanionSealedClass.FirstObject
+        InternalCompanionSealedClassEnum.InternalCompanionSealedClass_SecondObject ->
+                InternalCompanionSealedClass.SecondObject
+    }
+}
+
+/**
+ * The index of [this] in the values list.
+ */
+val InternalCompanionSealedClass.ordinal: Int
+    get() = InternalCompanionSealedClassSealedEnum.ordinalOf(this)
+
+/**
+ * The name of [this] for use with valueOf.
+ */
+val InternalCompanionSealedClass.name: String
+    get() = InternalCompanionSealedClassSealedEnum.nameOf(this)
+
+/**
+ * A list of all [InternalCompanionSealedClass] objects.
+ */
+internal val InternalCompanionSealedClass.Companion.values: List<InternalCompanionSealedClass>
+    get() = InternalCompanionSealedClassSealedEnum.values
+
+/**
+ * Returns an implementation of [SealedEnum] for the sealed class [InternalCompanionSealedClass]
+ */
+internal val InternalCompanionSealedClass.Companion.sealedEnum:
+        InternalCompanionSealedClassSealedEnum
+    get() = InternalCompanionSealedClassSealedEnum
+
+/**
+ * Returns the [InternalCompanionSealedClass] object for the given [name].
+ *
+ * If the given name doesn't correspond to any [InternalCompanionSealedClass], an
+ * [IllegalArgumentException] will be thrown.
+ */
+internal fun InternalCompanionSealedClass.Companion.valueOf(name: String):
+        InternalCompanionSealedClass = InternalCompanionSealedClassSealedEnum.valueOf(name)
+
+""".trimIndent()
+
+internal sealed class InternalSealedAndCompanionSealedClass {
+    object FirstObject : InternalSealedAndCompanionSealedClass()
+
+    internal object SecondObject : InternalSealedAndCompanionSealedClass()
+
+    @GenSealedEnum(generateEnum = true)
+    internal companion object
+}
+
+@Language("kotlin")
+val internalSealedAndCompanionSealedClassGenerated = """
+package com.livefront.sealedenum
+
+import java.lang.Class
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+/**
+ * An isomorphic enum for the sealed class [InternalSealedAndCompanionSealedClass]
+ */
+internal enum class InternalSealedAndCompanionSealedClassEnum {
+    InternalSealedAndCompanionSealedClass_FirstObject,
+
+    InternalSealedAndCompanionSealedClass_SecondObject
+}
+
+/**
+ * The isomorphic [InternalSealedAndCompanionSealedClassEnum] for [this].
+ */
+internal val InternalSealedAndCompanionSealedClass.enum: InternalSealedAndCompanionSealedClassEnum
+    get() = InternalSealedAndCompanionSealedClassSealedEnum.sealedObjectToEnum(this)
+
+/**
+ * The isomorphic [InternalSealedAndCompanionSealedClass] for [this].
+ */
+internal val InternalSealedAndCompanionSealedClassEnum.sealedObject:
+        InternalSealedAndCompanionSealedClass
+    get() = InternalSealedAndCompanionSealedClassSealedEnum.enumToSealedObject(this)
+
+/**
+ * An implementation of [SealedEnum] for the sealed class [InternalSealedAndCompanionSealedClass]
+ */
+internal object InternalSealedAndCompanionSealedClassSealedEnum :
+        SealedEnum<InternalSealedAndCompanionSealedClass>,
+        SealedEnumWithEnumProvider<InternalSealedAndCompanionSealedClass,
+        InternalSealedAndCompanionSealedClassEnum>,
+        EnumForSealedEnumProvider<InternalSealedAndCompanionSealedClass,
+        InternalSealedAndCompanionSealedClassEnum> {
+    override val values: List<InternalSealedAndCompanionSealedClass> = listOf(
+        InternalSealedAndCompanionSealedClass.FirstObject,
+        InternalSealedAndCompanionSealedClass.SecondObject
+    )
+
+
+    override val enumClass: Class<InternalSealedAndCompanionSealedClassEnum>
+        get() = InternalSealedAndCompanionSealedClassEnum::class.java
+
+    override fun ordinalOf(obj: InternalSealedAndCompanionSealedClass): Int = when (obj) {
+        InternalSealedAndCompanionSealedClass.FirstObject -> 0
+        InternalSealedAndCompanionSealedClass.SecondObject -> 1
+    }
+
+    override fun nameOf(obj: InternalSealedAndCompanionSealedClass): String = when (obj) {
+        InternalSealedAndCompanionSealedClass.FirstObject ->
+                "InternalSealedAndCompanionSealedClass_FirstObject"
+        InternalSealedAndCompanionSealedClass.SecondObject ->
+                "InternalSealedAndCompanionSealedClass_SecondObject"
+    }
+
+    override fun valueOf(name: String): InternalSealedAndCompanionSealedClass = when (name) {
+        "InternalSealedAndCompanionSealedClass_FirstObject" ->
+                InternalSealedAndCompanionSealedClass.FirstObject
+        "InternalSealedAndCompanionSealedClass_SecondObject" ->
+                InternalSealedAndCompanionSealedClass.SecondObject
+        else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
+    }
+
+    override fun sealedObjectToEnum(obj: InternalSealedAndCompanionSealedClass):
+            InternalSealedAndCompanionSealedClassEnum = when (obj) {
+        InternalSealedAndCompanionSealedClass.FirstObject ->
+                InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_FirstObject
+        InternalSealedAndCompanionSealedClass.SecondObject ->
+                InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_SecondObject
+    }
+
+    override fun enumToSealedObject(enum: InternalSealedAndCompanionSealedClassEnum):
+            InternalSealedAndCompanionSealedClass = when (enum) {
+        InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_FirstObject ->
+                InternalSealedAndCompanionSealedClass.FirstObject
+        InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_SecondObject ->
+                InternalSealedAndCompanionSealedClass.SecondObject
+    }
+}
+
+/**
+ * The index of [this] in the values list.
+ */
+internal val InternalSealedAndCompanionSealedClass.ordinal: Int
+    get() = InternalSealedAndCompanionSealedClassSealedEnum.ordinalOf(this)
+
+/**
+ * The name of [this] for use with valueOf.
+ */
+internal val InternalSealedAndCompanionSealedClass.name: String
+    get() = InternalSealedAndCompanionSealedClassSealedEnum.nameOf(this)
+
+/**
+ * A list of all [InternalSealedAndCompanionSealedClass] objects.
+ */
+internal val InternalSealedAndCompanionSealedClass.Companion.values:
+        List<InternalSealedAndCompanionSealedClass>
+    get() = InternalSealedAndCompanionSealedClassSealedEnum.values
+
+/**
+ * Returns an implementation of [SealedEnum] for the sealed class
+ * [InternalSealedAndCompanionSealedClass]
+ */
+internal val InternalSealedAndCompanionSealedClass.Companion.sealedEnum:
+        InternalSealedAndCompanionSealedClassSealedEnum
+    get() = InternalSealedAndCompanionSealedClassSealedEnum
+
+/**
+ * Returns the [InternalSealedAndCompanionSealedClass] object for the given [name].
+ *
+ * If the given name doesn't correspond to any [InternalSealedAndCompanionSealedClass], an
+ * [IllegalArgumentException] will be thrown.
+ */
+internal fun InternalSealedAndCompanionSealedClass.Companion.valueOf(name: String):
+        InternalSealedAndCompanionSealedClass =
+        InternalSealedAndCompanionSealedClassSealedEnum.valueOf(name)
+
+""".trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/VisibilitySealedClassTests.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/VisibilitySealedClassTests.kt
@@ -1,0 +1,251 @@
+package com.livefront.sealedenum
+
+import com.livefront.sealedenum.testing.assertCompiles
+import com.livefront.sealedenum.testing.assertGeneratedFileMatches
+import com.livefront.sealedenum.testing.compile
+import com.livefront.sealedenum.testing.getSourceFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KVisibility
+
+class VisibilitySealedClassTests {
+
+    @Nested
+    inner class InternalObjects {
+
+        @Test
+        fun `sealed enum class has correct visibility`() {
+            assertEquals(
+                KVisibility.PUBLIC,
+                InternalObjectsSealedClassSealedEnum::class.visibility
+            )
+
+        }
+
+        @Test
+        fun `internal objects have correct values`() {
+            assertEquals(
+                listOf(
+                    InternalObjectsSealedClass.FirstObject,
+                    InternalObjectsSealedClass.SecondObject,
+                    InternalObjectsSealedClass.InnerSealedClass.ThirdObject
+                ),
+                InternalObjectsSealedClass.values
+            )
+        }
+
+        @Test
+        fun `enums values are correct`() {
+            assertEquals(
+                listOf(
+                    InternalObjectsSealedClassEnum.InternalObjectsSealedClass_FirstObject,
+                    InternalObjectsSealedClassEnum.InternalObjectsSealedClass_SecondObject,
+                    InternalObjectsSealedClassEnum.InternalObjectsSealedClass_InnerSealedClass_ThirdObject
+                ),
+                enumValues<InternalObjectsSealedClassEnum>().toList()
+            )
+        }
+
+        @Test
+        fun `enums values are correct with mapping`() {
+            assertEquals(
+                InternalObjectsSealedClass.values.map(InternalObjectsSealedClass::enum),
+                enumValues<InternalObjectsSealedClassEnum>().toList()
+            )
+        }
+
+        @Test
+        fun `correct enum class`() {
+            assertEquals(InternalObjectsSealedClassEnum::class.java, InternalObjectsSealedClass.sealedEnum.enumClass)
+        }
+
+        @Test
+        fun `compilation generates correct code`() {
+            val result = compile(getSourceFile("VisibilitySealedClass.kt"))
+
+            assertCompiles(result)
+            assertGeneratedFileMatches(
+                "InternalObjectsSealedClass_SealedEnum.kt",
+                internalObjectsSealedClassGenerated,
+                result
+            )
+        }
+    }
+
+    @Nested
+    inner class Internal {
+
+        @Test
+        fun `sealed enum class has correct visibility`() {
+            assertEquals(
+                KVisibility.INTERNAL,
+                InternalSealedClassSealedEnum::class.visibility
+            )
+
+        }
+
+        @Test
+        fun `internal objects have correct values`() {
+            assertEquals(
+                listOf(InternalSealedClass.FirstObject, InternalSealedClass.SecondObject),
+                InternalSealedClass.values
+            )
+        }
+
+        @Test
+        fun `enums values are correct`() {
+            assertEquals(
+                listOf(
+                    InternalSealedClassEnum.InternalSealedClass_FirstObject,
+                    InternalSealedClassEnum.InternalSealedClass_SecondObject
+                ),
+                enumValues<InternalSealedClassEnum>().toList()
+            )
+        }
+
+        @Test
+        fun `enums values are correct with mapping`() {
+            assertEquals(
+                InternalSealedClass.values.map(InternalSealedClass::enum),
+                enumValues<InternalSealedClassEnum>().toList()
+            )
+        }
+
+        @Test
+        fun `correct enum class`() {
+            assertEquals(InternalSealedClassEnum::class.java, InternalSealedClass.sealedEnum.enumClass)
+        }
+
+        @Test
+        fun `compilation generates correct code`() {
+            val result = compile(getSourceFile("VisibilitySealedClass.kt"))
+
+            assertCompiles(result)
+            assertGeneratedFileMatches("InternalSealedClass_SealedEnum.kt", internalSealedClassGenerated, result)
+        }
+    }
+
+    @Nested
+    inner class InternalCompanion {
+
+        @Test
+        fun `sealed enum class has correct visibility`() {
+            assertEquals(
+                KVisibility.PUBLIC,
+                InternalCompanionSealedClassSealedEnum::class.visibility
+            )
+
+        }
+
+        @Test
+        fun `internal objects have correct values`() {
+            assertEquals(
+                listOf(InternalCompanionSealedClass.FirstObject, InternalCompanionSealedClass.SecondObject),
+                InternalCompanionSealedClass.values
+            )
+        }
+
+        @Test
+        fun `enums values are correct`() {
+            assertEquals(
+                listOf(
+                    InternalCompanionSealedClassEnum.InternalCompanionSealedClass_FirstObject,
+                    InternalCompanionSealedClassEnum.InternalCompanionSealedClass_SecondObject
+                ),
+                enumValues<InternalCompanionSealedClassEnum>().toList()
+            )
+        }
+
+        @Test
+        fun `enums values are correct with mapping`() {
+            assertEquals(
+                InternalCompanionSealedClass.values.map(InternalCompanionSealedClass::enum),
+                enumValues<InternalCompanionSealedClassEnum>().toList()
+            )
+        }
+
+        @Test
+        fun `correct enum class`() {
+            assertEquals(
+                InternalCompanionSealedClassEnum::class.java,
+                InternalCompanionSealedClass.sealedEnum.enumClass
+            )
+        }
+
+        @Test
+        fun `compilation generates correct code`() {
+            val result = compile(getSourceFile("VisibilitySealedClass.kt"))
+
+            assertCompiles(result)
+            assertGeneratedFileMatches(
+                "InternalCompanionSealedClass_SealedEnum.kt",
+                internalCompanionSealedClassGenerated,
+                result
+            )
+        }
+    }
+
+    @Nested
+    inner class InternalSealedAndCompanion {
+
+        @Test
+        fun `sealed enum class has correct visibility`() {
+            assertEquals(
+                KVisibility.INTERNAL,
+                InternalSealedAndCompanionSealedClassSealedEnum::class.visibility
+            )
+
+        }
+
+        @Test
+        fun `internal objects have correct values`() {
+            assertEquals(
+                listOf(
+                    InternalSealedAndCompanionSealedClass.FirstObject,
+                    InternalSealedAndCompanionSealedClass.SecondObject
+                ),
+                InternalSealedAndCompanionSealedClass.values
+            )
+        }
+
+        @Test
+        fun `enums values are correct`() {
+            assertEquals(
+                listOf(
+                    InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_FirstObject,
+                    InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_SecondObject
+                ),
+                enumValues<InternalSealedAndCompanionSealedClassEnum>().toList()
+            )
+        }
+
+        @Test
+        fun `enums values are correct with mapping`() {
+            assertEquals(
+                InternalSealedAndCompanionSealedClass.values.map(InternalSealedAndCompanionSealedClass::enum),
+                enumValues<InternalSealedAndCompanionSealedClassEnum>().toList()
+            )
+        }
+
+        @Test
+        fun `correct enum class`() {
+            assertEquals(
+                InternalSealedAndCompanionSealedClassEnum::class.java,
+                InternalSealedAndCompanionSealedClass.sealedEnum.enumClass
+            )
+        }
+
+        @Test
+        fun `compilation generates correct code`() {
+            val result = compile(getSourceFile("VisibilitySealedClass.kt"))
+
+            assertCompiles(result)
+            assertGeneratedFileMatches(
+                "InternalSealedAndCompanionSealedClass_SealedEnum.kt",
+                internalSealedAndCompanionSealedClassGenerated,
+                result
+            )
+        }
+    }
+}

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/errors/AnnotationErrors.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/errors/AnnotationErrors.kt
@@ -44,7 +44,7 @@ class AnnotationErrors {
         assertFails(result)
         assertTrue(result.messages.contains("Annotated element is not a Kotlin class"))
     }
-    
+
     @Test
     fun `annotated element is not a companion object`() {
         @Language("kotlin")
@@ -59,6 +59,42 @@ class AnnotationErrors {
 
         assertFails(result)
         assertTrue(result.messages.contains("Annotated element is not a companion object"))
+    }
+
+    @Test
+    fun `companion object is private`() {
+        @Language("kotlin")
+        val source = """
+            import com.livefront.sealedenum.GenSealedEnum
+            
+            sealed class PrivateCompanionObject {
+                @GenSealedEnum
+                private companion object
+            }
+        """.trimIndent()
+
+        val result = compile(SourceFile.kotlin("PrivateCompanionObject.kt", source))
+
+        assertFails(result)
+        assertTrue(result.messages.contains("Annotated companion object isn't internal or public"))
+    }
+
+    @Test
+    fun `companion object is protected`() {
+        @Language("kotlin")
+        val source = """
+            import com.livefront.sealedenum.GenSealedEnum
+            
+            sealed class ProtectedCompanionObject {
+                @GenSealedEnum
+                protected companion object
+            }
+        """.trimIndent()
+
+        val result = compile(SourceFile.kotlin("ProtectedCompanionObject.kt", source))
+
+        assertFails(result)
+        assertTrue(result.messages.contains("Annotated companion object isn't internal or public"))
     }
 
     @Test
@@ -77,5 +113,129 @@ class AnnotationErrors {
 
         assertFails(result)
         assertTrue(result.messages.contains("Annotated companion object is not for a sealed class"))
+    }
+
+    @Test
+    fun `sealed class is private`() {
+        @Language("kotlin")
+        val source = """
+            import com.livefront.sealedenum.GenSealedEnum
+            
+            class OuterClass {
+                private sealed class PrivateSealedClass {
+                    @GenSealedEnum
+                    companion object
+                }
+            }
+        """.trimIndent()
+
+        val result = compile(SourceFile.kotlin("OuterClass.kt", source))
+
+        assertFails(result)
+        assertTrue(result.messages.contains("Annotated sealed class isn't internal or public"))
+    }
+
+    @Test
+    fun `sealed class is protected`() {
+        @Language("kotlin")
+        val source = """
+            import com.livefront.sealedenum.GenSealedEnum
+            
+            class OuterClass {
+                protected sealed class ProtectedSealedClass {
+                    @GenSealedEnum
+                    companion object
+                }
+            }
+        """.trimIndent()
+
+        val result = compile(SourceFile.kotlin("OuterClass.kt", source))
+
+        assertFails(result)
+        assertTrue(result.messages.contains("Annotated sealed class isn't internal or public"))
+    }
+
+    @Test
+    fun `subclass sealed class is private`() {
+        @Language("kotlin")
+        val source = """
+            import com.livefront.sealedenum.GenSealedEnum
+            
+            sealed class OuterSealedClass {
+                private sealed class InnerSealedClass : OuterSealedClass() {
+                    object FirstObject : InnerSealedClass()
+                }
+                
+                @GenSealedEnum
+                companion object
+            }
+        """.trimIndent()
+
+        val result = compile(SourceFile.kotlin("OuterSealedClass.kt", source))
+
+        assertFails(result)
+        assertTrue(result.messages.contains("Subclass of sealed class isn't internal or public"))
+    }
+
+    @Test
+    fun `subclass sealed class is protected`() {
+        @Language("kotlin")
+        val source = """
+            import com.livefront.sealedenum.GenSealedEnum
+            
+            sealed class OuterSealedClass {
+                protected sealed class InnerSealedClass : OuterSealedClass() {
+                    object FirstObject : InnerSealedClass()
+                }
+                
+                @GenSealedEnum
+                companion object
+            }
+        """.trimIndent()
+
+        val result = compile(SourceFile.kotlin("OuterSealedClass.kt", source))
+
+        assertFails(result)
+        assertTrue(result.messages.contains("Subclass of sealed class isn't internal or public"))
+    }
+
+    @Test
+    fun `subclass object is private`() {
+        @Language("kotlin")
+        val source = """
+            import com.livefront.sealedenum.GenSealedEnum
+            
+            sealed class PrivateObject {
+                private object FirstObject : PrivateObject()
+                
+                @GenSealedEnum
+                companion object
+            }
+        """.trimIndent()
+
+        val result = compile(SourceFile.kotlin("PrivateObject.kt", source))
+
+        assertFails(result)
+        assertTrue(result.messages.contains("Subclass of sealed class isn't internal or public"))
+    }
+
+    @Test
+    fun `subclass object is protected`() {
+        @Language("kotlin")
+        val source = """
+            import com.livefront.sealedenum.GenSealedEnum
+            
+            sealed class PrivateObject {
+                protected object FirstObject : PrivateObject()
+                
+                @GenSealedEnum
+                companion object
+            }
+        """.trimIndent()
+
+        val result = compile(SourceFile.kotlin("PrivateObject.kt", source))
+
+        assertFails(result)
+        assertTrue(result.messages.contains("Subclass of sealed class isn't internal or public"))
     }
 }


### PR DESCRIPTION
The current functionality of `sealed-enum` assumes that the sealed class and companion object were both public. This PR adds handling for internal sealed classes and companion objects, as well as explicit errors for private or protected classes, and thus fixes #13.

This PR has two commits:

- The first just reorganizes all of the `*Spec` files into a `spec` package

- The second adds the visibility handling support