### PR TITLE
Create 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.2.0
+## Features:
+- Added extension properties and methods to make `sealed-enum` easier to use in common cases.
+  In particular, access to `values`, ordinals, names and the `SealedEnum` implementation can all be achieved without having to use a generated class name.
+- Added support for isomorphic enum generation via the `generateEnum` argument for `@GenSealedEnum`.
+  Isomorphism and class information can be retrieved from the implemented `EnumForSealedEnumProvider` interface.
+
+## Breaking changes:
+- `@GenSealedEnum` must now be applied to the companion object of `sealed class`, rather than the `sealed class` itself.
+- Processor option for auto-generation without `@GenSealedEnum` was removed.
+
+## Miscellaneous updates:
+- Updated to Kotlin 1.4
+- Switched to [`kotlin-compile-testing`](https://github.com/tschuchortdev/kotlin-compile-testing) for testing
+- Updated dependencies and created `buildSrc` for version management
+- Generated code is explicit-api-mode compatible by default (courtesy of KotlinPoet 1.7.x)
+
 # 0.1.1
 Publish dokka documentation and sources
 

--- a/README.md
+++ b/README.md
@@ -348,8 +348,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.livefront.sealed-enum:sealedenum:0.1.1")
-    kapt("com.github.livefront.sealed-enum:sealedenumprocessor:0.1.1")
+    implementation("com.github.livefront.sealed-enum:sealedenum:0.2.0")
+    kapt("com.github.livefront.sealed-enum:sealedenumprocessor:0.2.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 
 group=com.livefront.sealedenum
-version=0.1.1
+version=0.2.0


### PR DESCRIPTION
This PR prepares a 0.2.0 release. The main changes include the extension method and properties generation, as well as enum class generation, along with some version updates and the switch to `kotlin-compile-testing`.