### PR TITLE
Update dokka and remove link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,6 @@ dependencies {
 }
 ```
 
-### Class Documentation
-[Full class documentation for the runtime library is published automatically to JitPack](https://javadoc.jitpack.io/com/github/livefront/sealed-enum/sealedenum/latest/javadoc/sealedenum/index.html)
-
 ### License
 ```
 Copyright 2020 Livefront

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,13 +65,8 @@ subprojects {
             jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
 
-        val dokka by getting(org.jetbrains.dokka.gradle.DokkaTask::class) {
-            outputFormat = "html"
-            outputDirectory = javadoc.get().destinationDir!!.absolutePath
-
-            configuration {
-                jdkVersion = 8
-            }
+        dokkaHtml {
+            outputDirectory.set(javadoc.get().destinationDir)
         }
 
         val sourcesJar by creating(Jar::class) {
@@ -81,7 +76,7 @@ subprojects {
 
         val javadocJar by creating(Jar::class) {
             archiveClassifier.set("javadoc")
-            from(dokka)
+            from(dokkaHtml)
         }
 
         publishing {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val autoService = "1.0-rc7"
     const val detekt = "1.12.0"
-    const val dokka = "0.10.1"
+    const val dokka = "1.4.0"
     const val incap = "0.3"
     const val junit = "5.6.2"
     const val kotlin = "1.4.0"


### PR DESCRIPTION
This PR updates dokka to 1.4.0 and removes the link to the Jitpack Javadoc on the README pending #19 