### PR TITLE
Update to Kotlin-Poet 1.7.2

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,5 +6,5 @@ object Versions {
     const val junit = "5.6.2"
     const val kotlin = "1.4.0"
     const val kotlinCompileTesting = "1.2.11"
-    const val kotlinPoet = "1.6.0"
+    const val kotlinPoet = "1.7.2"
 }

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClass.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClass.kt
@@ -23,70 +23,70 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [EmptySealedClass]
  */
-enum class EmptySealedClassEnum
+public enum class EmptySealedClassEnum
 
 /**
  * The isomorphic [EmptySealedClassEnum] for [this].
  */
-val EmptySealedClass.enum: EmptySealedClassEnum
+public val EmptySealedClass.`enum`: EmptySealedClassEnum
     get() = EmptySealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [EmptySealedClass] for [this].
  */
-val EmptySealedClassEnum.sealedObject: EmptySealedClass
+public val EmptySealedClassEnum.sealedObject: EmptySealedClass
     get() = EmptySealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [EmptySealedClass]
  */
-object EmptySealedClassSealedEnum : SealedEnum<EmptySealedClass>,
+public object EmptySealedClassSealedEnum : SealedEnum<EmptySealedClass>,
         SealedEnumWithEnumProvider<EmptySealedClass, EmptySealedClassEnum>,
         EnumForSealedEnumProvider<EmptySealedClass, EmptySealedClassEnum> {
-    override val values: List<EmptySealedClass> = emptyList()
+    public override val values: List<EmptySealedClass> = emptyList()
 
 
-    override val enumClass: Class<EmptySealedClassEnum>
+    public override val enumClass: Class<EmptySealedClassEnum>
         get() = EmptySealedClassEnum::class.java
 
-    override fun ordinalOf(obj: EmptySealedClass): Int = throw
+    public override fun ordinalOf(obj: EmptySealedClass): Int = throw
             AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")
 
-    override fun nameOf(obj: EmptySealedClass): String = throw
+    public override fun nameOf(obj: EmptySealedClass): String = throw
             AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")
 
-    override fun valueOf(name: String): EmptySealedClass = throw
+    public override fun valueOf(name: String): EmptySealedClass = throw
             IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
 
-    override fun sealedObjectToEnum(obj: EmptySealedClass): EmptySealedClassEnum = throw
+    public override fun sealedObjectToEnum(obj: EmptySealedClass): EmptySealedClassEnum = throw
             AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")
 
-    override fun enumToSealedObject(enum: EmptySealedClassEnum): EmptySealedClass = throw
+    public override fun enumToSealedObject(`enum`: EmptySealedClassEnum): EmptySealedClass = throw
             AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")
 }
 
 /**
  * The index of [this] in the values list.
  */
-val EmptySealedClass.ordinal: Int
+public val EmptySealedClass.ordinal: Int
     get() = EmptySealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val EmptySealedClass.name: String
+public val EmptySealedClass.name: String
     get() = EmptySealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [EmptySealedClass] objects.
  */
-val EmptySealedClass.Companion.values: List<EmptySealedClass>
+public val EmptySealedClass.Companion.values: List<EmptySealedClass>
     get() = EmptySealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [EmptySealedClass]
  */
-val EmptySealedClass.Companion.sealedEnum: EmptySealedClassSealedEnum
+public val EmptySealedClass.Companion.sealedEnum: EmptySealedClassSealedEnum
     get() = EmptySealedClassSealedEnum
 
 /**
@@ -95,7 +95,7 @@ val EmptySealedClass.Companion.sealedEnum: EmptySealedClassSealedEnum
  * If the given name doesn't correspond to any [EmptySealedClass], an [IllegalArgumentException]
  * will be thrown.
  */
-fun EmptySealedClass.Companion.valueOf(name: String): EmptySealedClass =
+public fun EmptySealedClass.Companion.valueOf(name: String): EmptySealedClass =
         EmptySealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClass.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClass.kt
@@ -25,57 +25,57 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [OneObjectSealedClass]
  */
-enum class OneObjectSealedClassEnum {
-    OneObjectSealedClass_FirstObject
+public enum class OneObjectSealedClassEnum {
+    OneObjectSealedClass_FirstObject,
 }
 
 /**
  * The isomorphic [OneObjectSealedClassEnum] for [this].
  */
-val OneObjectSealedClass.enum: OneObjectSealedClassEnum
+public val OneObjectSealedClass.`enum`: OneObjectSealedClassEnum
     get() = OneObjectSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [OneObjectSealedClass] for [this].
  */
-val OneObjectSealedClassEnum.sealedObject: OneObjectSealedClass
+public val OneObjectSealedClassEnum.sealedObject: OneObjectSealedClass
     get() = OneObjectSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [OneObjectSealedClass]
  */
-object OneObjectSealedClassSealedEnum : SealedEnum<OneObjectSealedClass>,
+public object OneObjectSealedClassSealedEnum : SealedEnum<OneObjectSealedClass>,
         SealedEnumWithEnumProvider<OneObjectSealedClass, OneObjectSealedClassEnum>,
         EnumForSealedEnumProvider<OneObjectSealedClass, OneObjectSealedClassEnum> {
-    override val values: List<OneObjectSealedClass> = listOf(
+    public override val values: List<OneObjectSealedClass> = listOf(
         OneObjectSealedClass.FirstObject
     )
 
 
-    override val enumClass: Class<OneObjectSealedClassEnum>
+    public override val enumClass: Class<OneObjectSealedClassEnum>
         get() = OneObjectSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: OneObjectSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: OneObjectSealedClass): Int = when (obj) {
         OneObjectSealedClass.FirstObject -> 0
     }
 
-    override fun nameOf(obj: OneObjectSealedClass): String = when (obj) {
+    public override fun nameOf(obj: OneObjectSealedClass): String = when (obj) {
         OneObjectSealedClass.FirstObject -> "OneObjectSealedClass_FirstObject"
     }
 
-    override fun valueOf(name: String): OneObjectSealedClass = when (name) {
+    public override fun valueOf(name: String): OneObjectSealedClass = when (name) {
         "OneObjectSealedClass_FirstObject" -> OneObjectSealedClass.FirstObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: OneObjectSealedClass): OneObjectSealedClassEnum = when
-            (obj) {
+    public override fun sealedObjectToEnum(obj: OneObjectSealedClass): OneObjectSealedClassEnum =
+            when (obj) {
         OneObjectSealedClass.FirstObject ->
                 OneObjectSealedClassEnum.OneObjectSealedClass_FirstObject
     }
 
-    override fun enumToSealedObject(enum: OneObjectSealedClassEnum): OneObjectSealedClass = when
-            (enum) {
+    public override fun enumToSealedObject(`enum`: OneObjectSealedClassEnum): OneObjectSealedClass =
+            when (enum) {
         OneObjectSealedClassEnum.OneObjectSealedClass_FirstObject ->
                 OneObjectSealedClass.FirstObject
     }
@@ -84,25 +84,25 @@ object OneObjectSealedClassSealedEnum : SealedEnum<OneObjectSealedClass>,
 /**
  * The index of [this] in the values list.
  */
-val OneObjectSealedClass.ordinal: Int
+public val OneObjectSealedClass.ordinal: Int
     get() = OneObjectSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val OneObjectSealedClass.name: String
+public val OneObjectSealedClass.name: String
     get() = OneObjectSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [OneObjectSealedClass] objects.
  */
-val OneObjectSealedClass.Companion.values: List<OneObjectSealedClass>
+public val OneObjectSealedClass.Companion.values: List<OneObjectSealedClass>
     get() = OneObjectSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [OneObjectSealedClass]
  */
-val OneObjectSealedClass.Companion.sealedEnum: OneObjectSealedClassSealedEnum
+public val OneObjectSealedClass.Companion.sealedEnum: OneObjectSealedClassSealedEnum
     get() = OneObjectSealedClassSealedEnum
 
 /**
@@ -111,7 +111,7 @@ val OneObjectSealedClass.Companion.sealedEnum: OneObjectSealedClassSealedEnum
  * If the given name doesn't correspond to any [OneObjectSealedClass], an [IllegalArgumentException]
  * will be thrown.
  */
-fun OneObjectSealedClass.Companion.valueOf(name: String): OneObjectSealedClass =
+public fun OneObjectSealedClass.Companion.valueOf(name: String): OneObjectSealedClass =
         OneObjectSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClass.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClass.kt
@@ -27,65 +27,64 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [TwoObjectSealedClass]
  */
-enum class TwoObjectSealedClassEnum {
+public enum class TwoObjectSealedClassEnum {
     TwoObjectSealedClass_FirstObject,
-
-    TwoObjectSealedClass_SecondObject
+    TwoObjectSealedClass_SecondObject,
 }
 
 /**
  * The isomorphic [TwoObjectSealedClassEnum] for [this].
  */
-val TwoObjectSealedClass.enum: TwoObjectSealedClassEnum
+public val TwoObjectSealedClass.`enum`: TwoObjectSealedClassEnum
     get() = TwoObjectSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [TwoObjectSealedClass] for [this].
  */
-val TwoObjectSealedClassEnum.sealedObject: TwoObjectSealedClass
+public val TwoObjectSealedClassEnum.sealedObject: TwoObjectSealedClass
     get() = TwoObjectSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [TwoObjectSealedClass]
  */
-object TwoObjectSealedClassSealedEnum : SealedEnum<TwoObjectSealedClass>,
+public object TwoObjectSealedClassSealedEnum : SealedEnum<TwoObjectSealedClass>,
         SealedEnumWithEnumProvider<TwoObjectSealedClass, TwoObjectSealedClassEnum>,
         EnumForSealedEnumProvider<TwoObjectSealedClass, TwoObjectSealedClassEnum> {
-    override val values: List<TwoObjectSealedClass> = listOf(
+    public override val values: List<TwoObjectSealedClass> = listOf(
         TwoObjectSealedClass.FirstObject,
         TwoObjectSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<TwoObjectSealedClassEnum>
+    public override val enumClass: Class<TwoObjectSealedClassEnum>
         get() = TwoObjectSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: TwoObjectSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: TwoObjectSealedClass): Int = when (obj) {
         TwoObjectSealedClass.FirstObject -> 0
         TwoObjectSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: TwoObjectSealedClass): String = when (obj) {
+    public override fun nameOf(obj: TwoObjectSealedClass): String = when (obj) {
         TwoObjectSealedClass.FirstObject -> "TwoObjectSealedClass_FirstObject"
         TwoObjectSealedClass.SecondObject -> "TwoObjectSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): TwoObjectSealedClass = when (name) {
+    public override fun valueOf(name: String): TwoObjectSealedClass = when (name) {
         "TwoObjectSealedClass_FirstObject" -> TwoObjectSealedClass.FirstObject
         "TwoObjectSealedClass_SecondObject" -> TwoObjectSealedClass.SecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: TwoObjectSealedClass): TwoObjectSealedClassEnum = when
-            (obj) {
+    public override fun sealedObjectToEnum(obj: TwoObjectSealedClass): TwoObjectSealedClassEnum =
+            when (obj) {
         TwoObjectSealedClass.FirstObject ->
                 TwoObjectSealedClassEnum.TwoObjectSealedClass_FirstObject
         TwoObjectSealedClass.SecondObject ->
                 TwoObjectSealedClassEnum.TwoObjectSealedClass_SecondObject
     }
 
-    override fun enumToSealedObject(enum: TwoObjectSealedClassEnum): TwoObjectSealedClass = when
-            (enum) {
+    public override fun enumToSealedObject(`enum`: TwoObjectSealedClassEnum): TwoObjectSealedClass =
+            when (enum) {
         TwoObjectSealedClassEnum.TwoObjectSealedClass_FirstObject ->
                 TwoObjectSealedClass.FirstObject
         TwoObjectSealedClassEnum.TwoObjectSealedClass_SecondObject ->
@@ -96,25 +95,25 @@ object TwoObjectSealedClassSealedEnum : SealedEnum<TwoObjectSealedClass>,
 /**
  * The index of [this] in the values list.
  */
-val TwoObjectSealedClass.ordinal: Int
+public val TwoObjectSealedClass.ordinal: Int
     get() = TwoObjectSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val TwoObjectSealedClass.name: String
+public val TwoObjectSealedClass.name: String
     get() = TwoObjectSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [TwoObjectSealedClass] objects.
  */
-val TwoObjectSealedClass.Companion.values: List<TwoObjectSealedClass>
+public val TwoObjectSealedClass.Companion.values: List<TwoObjectSealedClass>
     get() = TwoObjectSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [TwoObjectSealedClass]
  */
-val TwoObjectSealedClass.Companion.sealedEnum: TwoObjectSealedClassSealedEnum
+public val TwoObjectSealedClass.Companion.sealedEnum: TwoObjectSealedClassSealedEnum
     get() = TwoObjectSealedClassSealedEnum
 
 /**
@@ -123,7 +122,7 @@ val TwoObjectSealedClass.Companion.sealedEnum: TwoObjectSealedClassSealedEnum
  * If the given name doesn't correspond to any [TwoObjectSealedClass], an [IllegalArgumentException]
  * will be thrown.
  */
-fun TwoObjectSealedClass.Companion.valueOf(name: String): TwoObjectSealedClass =
+public fun TwoObjectSealedClass.Companion.valueOf(name: String): TwoObjectSealedClass =
         TwoObjectSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
@@ -31,62 +31,60 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [OneTypeParameterSealedClass]
  */
-enum class OneTypeParameterSealedClassEnum {
+public enum class OneTypeParameterSealedClassEnum {
     OneTypeParameterSealedClass_FirstObject,
-
     OneTypeParameterSealedClass_SecondObject,
-
-    OneTypeParameterSealedClass_ThirdObject
+    OneTypeParameterSealedClass_ThirdObject,
 }
 
 /**
  * The isomorphic [OneTypeParameterSealedClassEnum] for [this].
  */
-val OneTypeParameterSealedClass<*>.enum: OneTypeParameterSealedClassEnum
+public val OneTypeParameterSealedClass<*>.`enum`: OneTypeParameterSealedClassEnum
     get() = OneTypeParameterSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [OneTypeParameterSealedClass] for [this].
  */
-val OneTypeParameterSealedClassEnum.sealedObject: OneTypeParameterSealedClass<*>
+public val OneTypeParameterSealedClassEnum.sealedObject: OneTypeParameterSealedClass<*>
     get() = OneTypeParameterSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [OneTypeParameterSealedClass]
  */
-object OneTypeParameterSealedClassSealedEnum : SealedEnum<OneTypeParameterSealedClass<*>>,
+public object OneTypeParameterSealedClassSealedEnum : SealedEnum<OneTypeParameterSealedClass<*>>,
         SealedEnumWithEnumProvider<OneTypeParameterSealedClass<*>, OneTypeParameterSealedClassEnum>,
         EnumForSealedEnumProvider<OneTypeParameterSealedClass<*>, OneTypeParameterSealedClassEnum> {
-    override val values: List<OneTypeParameterSealedClass<*>> = listOf(
+    public override val values: List<OneTypeParameterSealedClass<*>> = listOf(
         OneTypeParameterSealedClass.FirstObject,
         OneTypeParameterSealedClass.SecondObject,
         OneTypeParameterSealedClass.ThirdObject
     )
 
 
-    override val enumClass: Class<OneTypeParameterSealedClassEnum>
+    public override val enumClass: Class<OneTypeParameterSealedClassEnum>
         get() = OneTypeParameterSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: OneTypeParameterSealedClass<*>): Int = when (obj) {
+    public override fun ordinalOf(obj: OneTypeParameterSealedClass<*>): Int = when (obj) {
         OneTypeParameterSealedClass.FirstObject -> 0
         OneTypeParameterSealedClass.SecondObject -> 1
         OneTypeParameterSealedClass.ThirdObject -> 2
     }
 
-    override fun nameOf(obj: OneTypeParameterSealedClass<*>): String = when (obj) {
+    public override fun nameOf(obj: OneTypeParameterSealedClass<*>): String = when (obj) {
         OneTypeParameterSealedClass.FirstObject -> "OneTypeParameterSealedClass_FirstObject"
         OneTypeParameterSealedClass.SecondObject -> "OneTypeParameterSealedClass_SecondObject"
         OneTypeParameterSealedClass.ThirdObject -> "OneTypeParameterSealedClass_ThirdObject"
     }
 
-    override fun valueOf(name: String): OneTypeParameterSealedClass<*> = when (name) {
+    public override fun valueOf(name: String): OneTypeParameterSealedClass<*> = when (name) {
         "OneTypeParameterSealedClass_FirstObject" -> OneTypeParameterSealedClass.FirstObject
         "OneTypeParameterSealedClass_SecondObject" -> OneTypeParameterSealedClass.SecondObject
         "OneTypeParameterSealedClass_ThirdObject" -> OneTypeParameterSealedClass.ThirdObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: OneTypeParameterSealedClass<*>):
+    public override fun sealedObjectToEnum(obj: OneTypeParameterSealedClass<*>):
             OneTypeParameterSealedClassEnum = when (obj) {
         OneTypeParameterSealedClass.FirstObject ->
                 OneTypeParameterSealedClassEnum.OneTypeParameterSealedClass_FirstObject
@@ -96,7 +94,7 @@ object OneTypeParameterSealedClassSealedEnum : SealedEnum<OneTypeParameterSealed
                 OneTypeParameterSealedClassEnum.OneTypeParameterSealedClass_ThirdObject
     }
 
-    override fun enumToSealedObject(enum: OneTypeParameterSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: OneTypeParameterSealedClassEnum):
             OneTypeParameterSealedClass<*> = when (enum) {
         OneTypeParameterSealedClassEnum.OneTypeParameterSealedClass_FirstObject ->
                 OneTypeParameterSealedClass.FirstObject
@@ -110,25 +108,25 @@ object OneTypeParameterSealedClassSealedEnum : SealedEnum<OneTypeParameterSealed
 /**
  * The index of [this] in the values list.
  */
-val OneTypeParameterSealedClass<*>.ordinal: Int
+public val OneTypeParameterSealedClass<*>.ordinal: Int
     get() = OneTypeParameterSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val OneTypeParameterSealedClass<*>.name: String
+public val OneTypeParameterSealedClass<*>.name: String
     get() = OneTypeParameterSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [OneTypeParameterSealedClass] objects.
  */
-val OneTypeParameterSealedClass.OneType.values: List<OneTypeParameterSealedClass<*>>
+public val OneTypeParameterSealedClass.OneType.values: List<OneTypeParameterSealedClass<*>>
     get() = OneTypeParameterSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [OneTypeParameterSealedClass]
  */
-val OneTypeParameterSealedClass.OneType.sealedEnum: OneTypeParameterSealedClassSealedEnum
+public val OneTypeParameterSealedClass.OneType.sealedEnum: OneTypeParameterSealedClassSealedEnum
     get() = OneTypeParameterSealedClassSealedEnum
 
 /**
@@ -137,8 +135,8 @@ val OneTypeParameterSealedClass.OneType.sealedEnum: OneTypeParameterSealedClassS
  * If the given name doesn't correspond to any [OneTypeParameterSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun OneTypeParameterSealedClass.OneType.valueOf(name: String): OneTypeParameterSealedClass<*> =
-        OneTypeParameterSealedClassSealedEnum.valueOf(name)
+public fun OneTypeParameterSealedClass.OneType.valueOf(name: String): OneTypeParameterSealedClass<*>
+        = OneTypeParameterSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()
 
@@ -168,57 +166,56 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [TwoTypeParameterSealedClass]
  */
-enum class TwoTypeParameterSealedClassEnum {
+public enum class TwoTypeParameterSealedClassEnum {
     TwoTypeParameterSealedClass_FirstObject,
-
-    TwoTypeParameterSealedClass_SecondObject
+    TwoTypeParameterSealedClass_SecondObject,
 }
 
 /**
  * The isomorphic [TwoTypeParameterSealedClassEnum] for [this].
  */
-val TwoTypeParameterSealedClass<*, *>.enum: TwoTypeParameterSealedClassEnum
+public val TwoTypeParameterSealedClass<*, *>.`enum`: TwoTypeParameterSealedClassEnum
     get() = TwoTypeParameterSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [TwoTypeParameterSealedClass] for [this].
  */
-val TwoTypeParameterSealedClassEnum.sealedObject: TwoTypeParameterSealedClass<*, *>
+public val TwoTypeParameterSealedClassEnum.sealedObject: TwoTypeParameterSealedClass<*, *>
     get() = TwoTypeParameterSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [TwoTypeParameterSealedClass]
  */
-object TwoTypeParameterSealedClassSealedEnum : SealedEnum<TwoTypeParameterSealedClass<*, *>>,
+public object TwoTypeParameterSealedClassSealedEnum : SealedEnum<TwoTypeParameterSealedClass<*, *>>,
         SealedEnumWithEnumProvider<TwoTypeParameterSealedClass<*, *>,
         TwoTypeParameterSealedClassEnum>, EnumForSealedEnumProvider<TwoTypeParameterSealedClass<*,
         *>, TwoTypeParameterSealedClassEnum> {
-    override val values: List<TwoTypeParameterSealedClass<*, *>> = listOf(
+    public override val values: List<TwoTypeParameterSealedClass<*, *>> = listOf(
         TwoTypeParameterSealedClass.FirstObject,
         TwoTypeParameterSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<TwoTypeParameterSealedClassEnum>
+    public override val enumClass: Class<TwoTypeParameterSealedClassEnum>
         get() = TwoTypeParameterSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: TwoTypeParameterSealedClass<*, *>): Int = when (obj) {
+    public override fun ordinalOf(obj: TwoTypeParameterSealedClass<*, *>): Int = when (obj) {
         TwoTypeParameterSealedClass.FirstObject -> 0
         TwoTypeParameterSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: TwoTypeParameterSealedClass<*, *>): String = when (obj) {
+    public override fun nameOf(obj: TwoTypeParameterSealedClass<*, *>): String = when (obj) {
         TwoTypeParameterSealedClass.FirstObject -> "TwoTypeParameterSealedClass_FirstObject"
         TwoTypeParameterSealedClass.SecondObject -> "TwoTypeParameterSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): TwoTypeParameterSealedClass<*, *> = when (name) {
+    public override fun valueOf(name: String): TwoTypeParameterSealedClass<*, *> = when (name) {
         "TwoTypeParameterSealedClass_FirstObject" -> TwoTypeParameterSealedClass.FirstObject
         "TwoTypeParameterSealedClass_SecondObject" -> TwoTypeParameterSealedClass.SecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: TwoTypeParameterSealedClass<*, *>):
+    public override fun sealedObjectToEnum(obj: TwoTypeParameterSealedClass<*, *>):
             TwoTypeParameterSealedClassEnum = when (obj) {
         TwoTypeParameterSealedClass.FirstObject ->
                 TwoTypeParameterSealedClassEnum.TwoTypeParameterSealedClass_FirstObject
@@ -226,7 +223,7 @@ object TwoTypeParameterSealedClassSealedEnum : SealedEnum<TwoTypeParameterSealed
                 TwoTypeParameterSealedClassEnum.TwoTypeParameterSealedClass_SecondObject
     }
 
-    override fun enumToSealedObject(enum: TwoTypeParameterSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: TwoTypeParameterSealedClassEnum):
             TwoTypeParameterSealedClass<*, *> = when (enum) {
         TwoTypeParameterSealedClassEnum.TwoTypeParameterSealedClass_FirstObject ->
                 TwoTypeParameterSealedClass.FirstObject
@@ -238,25 +235,25 @@ object TwoTypeParameterSealedClassSealedEnum : SealedEnum<TwoTypeParameterSealed
 /**
  * The index of [this] in the values list.
  */
-val TwoTypeParameterSealedClass<*, *>.ordinal: Int
+public val TwoTypeParameterSealedClass<*, *>.ordinal: Int
     get() = TwoTypeParameterSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val TwoTypeParameterSealedClass<*, *>.name: String
+public val TwoTypeParameterSealedClass<*, *>.name: String
     get() = TwoTypeParameterSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [TwoTypeParameterSealedClass] objects.
  */
-val TwoTypeParameterSealedClass.TwoType.values: List<TwoTypeParameterSealedClass<*, *>>
+public val TwoTypeParameterSealedClass.TwoType.values: List<TwoTypeParameterSealedClass<*, *>>
     get() = TwoTypeParameterSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [TwoTypeParameterSealedClass]
  */
-val TwoTypeParameterSealedClass.TwoType.sealedEnum: TwoTypeParameterSealedClassSealedEnum
+public val TwoTypeParameterSealedClass.TwoType.sealedEnum: TwoTypeParameterSealedClassSealedEnum
     get() = TwoTypeParameterSealedClassSealedEnum
 
 /**
@@ -265,8 +262,8 @@ val TwoTypeParameterSealedClass.TwoType.sealedEnum: TwoTypeParameterSealedClassS
  * If the given name doesn't correspond to any [TwoTypeParameterSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun TwoTypeParameterSealedClass.TwoType.valueOf(name: String): TwoTypeParameterSealedClass<*, *> =
-        TwoTypeParameterSealedClassSealedEnum.valueOf(name)
+public fun TwoTypeParameterSealedClass.TwoType.valueOf(name: String): TwoTypeParameterSealedClass<*,
+        *> = TwoTypeParameterSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()
 
@@ -296,60 +293,60 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [LimitedTypeParameterSealedClass]
  */
-enum class LimitedTypeParameterSealedClassEnum {
+public enum class LimitedTypeParameterSealedClassEnum {
     LimitedTypeParameterSealedClass_FirstObject,
-
-    LimitedTypeParameterSealedClass_SecondObject
+    LimitedTypeParameterSealedClass_SecondObject,
 }
 
 /**
  * The isomorphic [LimitedTypeParameterSealedClassEnum] for [this].
  */
-val LimitedTypeParameterSealedClass<*, *>.enum: LimitedTypeParameterSealedClassEnum
+public val LimitedTypeParameterSealedClass<*, *>.`enum`: LimitedTypeParameterSealedClassEnum
     get() = LimitedTypeParameterSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [LimitedTypeParameterSealedClass] for [this].
  */
-val LimitedTypeParameterSealedClassEnum.sealedObject: LimitedTypeParameterSealedClass<*, *>
+public val LimitedTypeParameterSealedClassEnum.sealedObject: LimitedTypeParameterSealedClass<*, *>
     get() = LimitedTypeParameterSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [LimitedTypeParameterSealedClass]
  */
-object LimitedTypeParameterSealedClassSealedEnum : SealedEnum<LimitedTypeParameterSealedClass<*,
-        *>>, SealedEnumWithEnumProvider<LimitedTypeParameterSealedClass<*, *>,
+public object LimitedTypeParameterSealedClassSealedEnum :
+        SealedEnum<LimitedTypeParameterSealedClass<*, *>>,
+        SealedEnumWithEnumProvider<LimitedTypeParameterSealedClass<*, *>,
         LimitedTypeParameterSealedClassEnum>,
         EnumForSealedEnumProvider<LimitedTypeParameterSealedClass<*, *>,
         LimitedTypeParameterSealedClassEnum> {
-    override val values: List<LimitedTypeParameterSealedClass<*, *>> = listOf(
+    public override val values: List<LimitedTypeParameterSealedClass<*, *>> = listOf(
         LimitedTypeParameterSealedClass.FirstObject,
         LimitedTypeParameterSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<LimitedTypeParameterSealedClassEnum>
+    public override val enumClass: Class<LimitedTypeParameterSealedClassEnum>
         get() = LimitedTypeParameterSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: LimitedTypeParameterSealedClass<*, *>): Int = when (obj) {
+    public override fun ordinalOf(obj: LimitedTypeParameterSealedClass<*, *>): Int = when (obj) {
         LimitedTypeParameterSealedClass.FirstObject -> 0
         LimitedTypeParameterSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: LimitedTypeParameterSealedClass<*, *>): String = when (obj) {
+    public override fun nameOf(obj: LimitedTypeParameterSealedClass<*, *>): String = when (obj) {
         LimitedTypeParameterSealedClass.FirstObject -> "LimitedTypeParameterSealedClass_FirstObject"
         LimitedTypeParameterSealedClass.SecondObject ->
                 "LimitedTypeParameterSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): LimitedTypeParameterSealedClass<*, *> = when (name) {
+    public override fun valueOf(name: String): LimitedTypeParameterSealedClass<*, *> = when (name) {
         "LimitedTypeParameterSealedClass_FirstObject" -> LimitedTypeParameterSealedClass.FirstObject
         "LimitedTypeParameterSealedClass_SecondObject" ->
                 LimitedTypeParameterSealedClass.SecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: LimitedTypeParameterSealedClass<*, *>):
+    public override fun sealedObjectToEnum(obj: LimitedTypeParameterSealedClass<*, *>):
             LimitedTypeParameterSealedClassEnum = when (obj) {
         LimitedTypeParameterSealedClass.FirstObject ->
                 LimitedTypeParameterSealedClassEnum.LimitedTypeParameterSealedClass_FirstObject
@@ -357,7 +354,7 @@ object LimitedTypeParameterSealedClassSealedEnum : SealedEnum<LimitedTypeParamet
                 LimitedTypeParameterSealedClassEnum.LimitedTypeParameterSealedClass_SecondObject
     }
 
-    override fun enumToSealedObject(enum: LimitedTypeParameterSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: LimitedTypeParameterSealedClassEnum):
             LimitedTypeParameterSealedClass<*, *> = when (enum) {
         LimitedTypeParameterSealedClassEnum.LimitedTypeParameterSealedClass_FirstObject ->
                 LimitedTypeParameterSealedClass.FirstObject
@@ -369,25 +366,26 @@ object LimitedTypeParameterSealedClassSealedEnum : SealedEnum<LimitedTypeParamet
 /**
  * The index of [this] in the values list.
  */
-val LimitedTypeParameterSealedClass<*, *>.ordinal: Int
+public val LimitedTypeParameterSealedClass<*, *>.ordinal: Int
     get() = LimitedTypeParameterSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val LimitedTypeParameterSealedClass<*, *>.name: String
+public val LimitedTypeParameterSealedClass<*, *>.name: String
     get() = LimitedTypeParameterSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [LimitedTypeParameterSealedClass] objects.
  */
-val LimitedTypeParameterSealedClass.LimitedType.values: List<LimitedTypeParameterSealedClass<*, *>>
+public val LimitedTypeParameterSealedClass.LimitedType.values:
+        List<LimitedTypeParameterSealedClass<*, *>>
     get() = LimitedTypeParameterSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [LimitedTypeParameterSealedClass]
  */
-val LimitedTypeParameterSealedClass.LimitedType.sealedEnum:
+public val LimitedTypeParameterSealedClass.LimitedType.sealedEnum:
         LimitedTypeParameterSealedClassSealedEnum
     get() = LimitedTypeParameterSealedClassSealedEnum
 
@@ -397,7 +395,7 @@ val LimitedTypeParameterSealedClass.LimitedType.sealedEnum:
  * If the given name doesn't correspond to any [LimitedTypeParameterSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun LimitedTypeParameterSealedClass.LimitedType.valueOf(name: String):
+public fun LimitedTypeParameterSealedClass.LimitedType.valueOf(name: String):
         LimitedTypeParameterSealedClass<*, *> =
         LimitedTypeParameterSealedClassSealedEnum.valueOf(name)
 
@@ -431,56 +429,56 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [MultipleBoundsSealedClass]
  */
-enum class MultipleBoundsSealedClassEnum {
-    MultipleBoundsSealedClass_FirstObject
+public enum class MultipleBoundsSealedClassEnum {
+    MultipleBoundsSealedClass_FirstObject,
 }
 
 /**
  * The isomorphic [MultipleBoundsSealedClassEnum] for [this].
  */
-val MultipleBoundsSealedClass<*>.enum: MultipleBoundsSealedClassEnum
+public val MultipleBoundsSealedClass<*>.`enum`: MultipleBoundsSealedClassEnum
     get() = MultipleBoundsSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [MultipleBoundsSealedClass] for [this].
  */
-val MultipleBoundsSealedClassEnum.sealedObject: MultipleBoundsSealedClass<*>
+public val MultipleBoundsSealedClassEnum.sealedObject: MultipleBoundsSealedClass<*>
     get() = MultipleBoundsSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [MultipleBoundsSealedClass]
  */
-object MultipleBoundsSealedClassSealedEnum : SealedEnum<MultipleBoundsSealedClass<*>>,
+public object MultipleBoundsSealedClassSealedEnum : SealedEnum<MultipleBoundsSealedClass<*>>,
         SealedEnumWithEnumProvider<MultipleBoundsSealedClass<*>, MultipleBoundsSealedClassEnum>,
         EnumForSealedEnumProvider<MultipleBoundsSealedClass<*>, MultipleBoundsSealedClassEnum> {
-    override val values: List<MultipleBoundsSealedClass<*>> = listOf(
+    public override val values: List<MultipleBoundsSealedClass<*>> = listOf(
         MultipleBoundsSealedClass.FirstObject
     )
 
 
-    override val enumClass: Class<MultipleBoundsSealedClassEnum>
+    public override val enumClass: Class<MultipleBoundsSealedClassEnum>
         get() = MultipleBoundsSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: MultipleBoundsSealedClass<*>): Int = when (obj) {
+    public override fun ordinalOf(obj: MultipleBoundsSealedClass<*>): Int = when (obj) {
         MultipleBoundsSealedClass.FirstObject -> 0
     }
 
-    override fun nameOf(obj: MultipleBoundsSealedClass<*>): String = when (obj) {
+    public override fun nameOf(obj: MultipleBoundsSealedClass<*>): String = when (obj) {
         MultipleBoundsSealedClass.FirstObject -> "MultipleBoundsSealedClass_FirstObject"
     }
 
-    override fun valueOf(name: String): MultipleBoundsSealedClass<*> = when (name) {
+    public override fun valueOf(name: String): MultipleBoundsSealedClass<*> = when (name) {
         "MultipleBoundsSealedClass_FirstObject" -> MultipleBoundsSealedClass.FirstObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: MultipleBoundsSealedClass<*>):
+    public override fun sealedObjectToEnum(obj: MultipleBoundsSealedClass<*>):
             MultipleBoundsSealedClassEnum = when (obj) {
         MultipleBoundsSealedClass.FirstObject ->
                 MultipleBoundsSealedClassEnum.MultipleBoundsSealedClass_FirstObject
     }
 
-    override fun enumToSealedObject(enum: MultipleBoundsSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: MultipleBoundsSealedClassEnum):
             MultipleBoundsSealedClass<*> = when (enum) {
         MultipleBoundsSealedClassEnum.MultipleBoundsSealedClass_FirstObject ->
                 MultipleBoundsSealedClass.FirstObject
@@ -490,25 +488,25 @@ object MultipleBoundsSealedClassSealedEnum : SealedEnum<MultipleBoundsSealedClas
 /**
  * The index of [this] in the values list.
  */
-val MultipleBoundsSealedClass<*>.ordinal: Int
+public val MultipleBoundsSealedClass<*>.ordinal: Int
     get() = MultipleBoundsSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val MultipleBoundsSealedClass<*>.name: String
+public val MultipleBoundsSealedClass<*>.name: String
     get() = MultipleBoundsSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [MultipleBoundsSealedClass] objects.
  */
-val MultipleBoundsSealedClass.Companion.values: List<MultipleBoundsSealedClass<*>>
+public val MultipleBoundsSealedClass.Companion.values: List<MultipleBoundsSealedClass<*>>
     get() = MultipleBoundsSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [MultipleBoundsSealedClass]
  */
-val MultipleBoundsSealedClass.Companion.sealedEnum: MultipleBoundsSealedClassSealedEnum
+public val MultipleBoundsSealedClass.Companion.sealedEnum: MultipleBoundsSealedClassSealedEnum
     get() = MultipleBoundsSealedClassSealedEnum
 
 /**
@@ -517,7 +515,7 @@ val MultipleBoundsSealedClass.Companion.sealedEnum: MultipleBoundsSealedClassSea
  * If the given name doesn't correspond to any [MultipleBoundsSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun MultipleBoundsSealedClass.Companion.valueOf(name: String): MultipleBoundsSealedClass<*> =
+public fun MultipleBoundsSealedClass.Companion.valueOf(name: String): MultipleBoundsSealedClass<*> =
         MultipleBoundsSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithAbstractBaseClasses.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithAbstractBaseClasses.kt
@@ -34,7 +34,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [SealedEnumWithAbstractBaseClasses]
  */
-enum class SealedEnumWithAbstractBaseClassesEnum(
+public enum class SealedEnumWithAbstractBaseClassesEnum(
     sealedObject: SealedEnumWithAbstractBaseClasses
 ) : BaseClassInterface2<String> by sealedObject, BaseClassInterface1<BaseClassInterface1<Any?>> by
         sealedObject
@@ -42,43 +42,44 @@ enum class SealedEnumWithAbstractBaseClassesEnum(
 /**
  * The isomorphic [SealedEnumWithAbstractBaseClassesEnum] for [this].
  */
-val SealedEnumWithAbstractBaseClasses.enum: SealedEnumWithAbstractBaseClassesEnum
+public val SealedEnumWithAbstractBaseClasses.`enum`: SealedEnumWithAbstractBaseClassesEnum
     get() = SealedEnumWithAbstractBaseClassesSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [SealedEnumWithAbstractBaseClasses] for [this].
  */
-val SealedEnumWithAbstractBaseClassesEnum.sealedObject: SealedEnumWithAbstractBaseClasses
+public val SealedEnumWithAbstractBaseClassesEnum.sealedObject: SealedEnumWithAbstractBaseClasses
     get() = SealedEnumWithAbstractBaseClassesSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [SealedEnumWithAbstractBaseClasses]
  */
-object SealedEnumWithAbstractBaseClassesSealedEnum : SealedEnum<SealedEnumWithAbstractBaseClasses>,
+public object SealedEnumWithAbstractBaseClassesSealedEnum :
+        SealedEnum<SealedEnumWithAbstractBaseClasses>,
         SealedEnumWithEnumProvider<SealedEnumWithAbstractBaseClasses,
         SealedEnumWithAbstractBaseClassesEnum>,
         EnumForSealedEnumProvider<SealedEnumWithAbstractBaseClasses,
         SealedEnumWithAbstractBaseClassesEnum> {
-    override val values: List<SealedEnumWithAbstractBaseClasses> = emptyList()
+    public override val values: List<SealedEnumWithAbstractBaseClasses> = emptyList()
 
 
-    override val enumClass: Class<SealedEnumWithAbstractBaseClassesEnum>
+    public override val enumClass: Class<SealedEnumWithAbstractBaseClassesEnum>
         get() = SealedEnumWithAbstractBaseClassesEnum::class.java
 
-    override fun ordinalOf(obj: SealedEnumWithAbstractBaseClasses): Int = throw
+    public override fun ordinalOf(obj: SealedEnumWithAbstractBaseClasses): Int = throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClasses is impossible, since it has no sealed subclasses")
 
-    override fun nameOf(obj: SealedEnumWithAbstractBaseClasses): String = throw
+    public override fun nameOf(obj: SealedEnumWithAbstractBaseClasses): String = throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClasses is impossible, since it has no sealed subclasses")
 
-    override fun valueOf(name: String): SealedEnumWithAbstractBaseClasses = throw
+    public override fun valueOf(name: String): SealedEnumWithAbstractBaseClasses = throw
             IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
 
-    override fun sealedObjectToEnum(obj: SealedEnumWithAbstractBaseClasses):
+    public override fun sealedObjectToEnum(obj: SealedEnumWithAbstractBaseClasses):
             SealedEnumWithAbstractBaseClassesEnum = throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClasses is impossible, since it has no sealed subclasses")
 
-    override fun enumToSealedObject(enum: SealedEnumWithAbstractBaseClassesEnum):
+    public override fun enumToSealedObject(`enum`: SealedEnumWithAbstractBaseClassesEnum):
             SealedEnumWithAbstractBaseClasses = throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClasses is impossible, since it has no sealed subclasses")
 }
@@ -86,26 +87,27 @@ object SealedEnumWithAbstractBaseClassesSealedEnum : SealedEnum<SealedEnumWithAb
 /**
  * The index of [this] in the values list.
  */
-val SealedEnumWithAbstractBaseClasses.ordinal: Int
+public val SealedEnumWithAbstractBaseClasses.ordinal: Int
     get() = SealedEnumWithAbstractBaseClassesSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val SealedEnumWithAbstractBaseClasses.name: String
+public val SealedEnumWithAbstractBaseClasses.name: String
     get() = SealedEnumWithAbstractBaseClassesSealedEnum.nameOf(this)
 
 /**
  * A list of all [SealedEnumWithAbstractBaseClasses] objects.
  */
-val SealedEnumWithAbstractBaseClasses.Companion.values: List<SealedEnumWithAbstractBaseClasses>
+public val SealedEnumWithAbstractBaseClasses.Companion.values:
+        List<SealedEnumWithAbstractBaseClasses>
     get() = SealedEnumWithAbstractBaseClassesSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class
  * [SealedEnumWithAbstractBaseClasses]
  */
-val SealedEnumWithAbstractBaseClasses.Companion.sealedEnum:
+public val SealedEnumWithAbstractBaseClasses.Companion.sealedEnum:
         SealedEnumWithAbstractBaseClassesSealedEnum
     get() = SealedEnumWithAbstractBaseClassesSealedEnum
 
@@ -115,7 +117,7 @@ val SealedEnumWithAbstractBaseClasses.Companion.sealedEnum:
  * If the given name doesn't correspond to any [SealedEnumWithAbstractBaseClasses], an
  * [IllegalArgumentException] will be thrown.
  */
-fun SealedEnumWithAbstractBaseClasses.Companion.valueOf(name: String):
+public fun SealedEnumWithAbstractBaseClasses.Companion.valueOf(name: String):
         SealedEnumWithAbstractBaseClasses =
         SealedEnumWithAbstractBaseClassesSealedEnum.valueOf(name)
 
@@ -145,21 +147,21 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [SealedEnumWithAbstractBaseClassesCovariantType]
  */
-enum class SealedEnumWithAbstractBaseClassesCovariantTypeEnum(
+public enum class SealedEnumWithAbstractBaseClassesCovariantTypeEnum(
     sealedObject: SealedEnumWithAbstractBaseClassesCovariantType<*>
 ) : BaseClassInterface3<BaseClassInterface3<*>> by sealedObject
 
 /**
  * The isomorphic [SealedEnumWithAbstractBaseClassesCovariantTypeEnum] for [this].
  */
-val SealedEnumWithAbstractBaseClassesCovariantType<*>.enum:
+public val SealedEnumWithAbstractBaseClassesCovariantType<*>.`enum`:
         SealedEnumWithAbstractBaseClassesCovariantTypeEnum
     get() = SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [SealedEnumWithAbstractBaseClassesCovariantType] for [this].
  */
-val SealedEnumWithAbstractBaseClassesCovariantTypeEnum.sealedObject:
+public val SealedEnumWithAbstractBaseClassesCovariantTypeEnum.sealedObject:
         SealedEnumWithAbstractBaseClassesCovariantType<*>
     get() = SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum.enumToSealedObject(this)
 
@@ -167,32 +169,36 @@ val SealedEnumWithAbstractBaseClassesCovariantTypeEnum.sealedObject:
  * An implementation of [SealedEnum] for the sealed class
  * [SealedEnumWithAbstractBaseClassesCovariantType]
  */
-object SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum :
+public object SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum :
         SealedEnum<SealedEnumWithAbstractBaseClassesCovariantType<*>>,
         SealedEnumWithEnumProvider<SealedEnumWithAbstractBaseClassesCovariantType<*>,
         SealedEnumWithAbstractBaseClassesCovariantTypeEnum>,
         EnumForSealedEnumProvider<SealedEnumWithAbstractBaseClassesCovariantType<*>,
         SealedEnumWithAbstractBaseClassesCovariantTypeEnum> {
-    override val values: List<SealedEnumWithAbstractBaseClassesCovariantType<*>> = emptyList()
+    public override val values: List<SealedEnumWithAbstractBaseClassesCovariantType<*>> =
+            emptyList()
 
 
-    override val enumClass: Class<SealedEnumWithAbstractBaseClassesCovariantTypeEnum>
+    public override val enumClass: Class<SealedEnumWithAbstractBaseClassesCovariantTypeEnum>
         get() = SealedEnumWithAbstractBaseClassesCovariantTypeEnum::class.java
 
-    override fun ordinalOf(obj: SealedEnumWithAbstractBaseClassesCovariantType<*>): Int = throw
+    public override fun ordinalOf(obj: SealedEnumWithAbstractBaseClassesCovariantType<*>): Int =
+            throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClassesCovariantType is impossible, since it has no sealed subclasses")
 
-    override fun nameOf(obj: SealedEnumWithAbstractBaseClassesCovariantType<*>): String = throw
+    public override fun nameOf(obj: SealedEnumWithAbstractBaseClassesCovariantType<*>): String =
+            throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClassesCovariantType is impossible, since it has no sealed subclasses")
 
-    override fun valueOf(name: String): SealedEnumWithAbstractBaseClassesCovariantType<*> = throw
-            IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
+    public override fun valueOf(name: String): SealedEnumWithAbstractBaseClassesCovariantType<*> =
+            throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
 
-    override fun sealedObjectToEnum(obj: SealedEnumWithAbstractBaseClassesCovariantType<*>):
+    public override fun sealedObjectToEnum(obj: SealedEnumWithAbstractBaseClassesCovariantType<*>):
             SealedEnumWithAbstractBaseClassesCovariantTypeEnum = throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClassesCovariantType is impossible, since it has no sealed subclasses")
 
-    override fun enumToSealedObject(enum: SealedEnumWithAbstractBaseClassesCovariantTypeEnum):
+    public override
+            fun enumToSealedObject(`enum`: SealedEnumWithAbstractBaseClassesCovariantTypeEnum):
             SealedEnumWithAbstractBaseClassesCovariantType<*> = throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClassesCovariantType is impossible, since it has no sealed subclasses")
 }
@@ -200,19 +206,19 @@ object SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum :
 /**
  * The index of [this] in the values list.
  */
-val SealedEnumWithAbstractBaseClassesCovariantType<*>.ordinal: Int
+public val SealedEnumWithAbstractBaseClassesCovariantType<*>.ordinal: Int
     get() = SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val SealedEnumWithAbstractBaseClassesCovariantType<*>.name: String
+public val SealedEnumWithAbstractBaseClassesCovariantType<*>.name: String
     get() = SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum.nameOf(this)
 
 /**
  * A list of all [SealedEnumWithAbstractBaseClassesCovariantType] objects.
  */
-val SealedEnumWithAbstractBaseClassesCovariantType.Companion.values:
+public val SealedEnumWithAbstractBaseClassesCovariantType.Companion.values:
         List<SealedEnumWithAbstractBaseClassesCovariantType<*>>
     get() = SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum.values
 
@@ -220,7 +226,7 @@ val SealedEnumWithAbstractBaseClassesCovariantType.Companion.values:
  * Returns an implementation of [SealedEnum] for the sealed class
  * [SealedEnumWithAbstractBaseClassesCovariantType]
  */
-val SealedEnumWithAbstractBaseClassesCovariantType.Companion.sealedEnum:
+public val SealedEnumWithAbstractBaseClassesCovariantType.Companion.sealedEnum:
         SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum
     get() = SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum
 
@@ -230,7 +236,7 @@ val SealedEnumWithAbstractBaseClassesCovariantType.Companion.sealedEnum:
  * If the given name doesn't correspond to any [SealedEnumWithAbstractBaseClassesCovariantType], an
  * [IllegalArgumentException] will be thrown.
  */
-fun SealedEnumWithAbstractBaseClassesCovariantType.Companion.valueOf(name: String):
+public fun SealedEnumWithAbstractBaseClassesCovariantType.Companion.valueOf(name: String):
         SealedEnumWithAbstractBaseClassesCovariantType<*> =
         SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum.valueOf(name)
 

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithInterfaces.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithInterfaces.kt
@@ -31,49 +31,49 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [EmptySealedClassWithInterface]
  */
-enum class EmptySealedClassWithInterfaceEnum(
+public enum class EmptySealedClassWithInterfaceEnum(
     sealedObject: EmptySealedClassWithInterface
 ) : TestInterface by sealedObject
 
 /**
  * The isomorphic [EmptySealedClassWithInterfaceEnum] for [this].
  */
-val EmptySealedClassWithInterface.enum: EmptySealedClassWithInterfaceEnum
+public val EmptySealedClassWithInterface.`enum`: EmptySealedClassWithInterfaceEnum
     get() = EmptySealedClassWithInterfaceSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [EmptySealedClassWithInterface] for [this].
  */
-val EmptySealedClassWithInterfaceEnum.sealedObject: EmptySealedClassWithInterface
+public val EmptySealedClassWithInterfaceEnum.sealedObject: EmptySealedClassWithInterface
     get() = EmptySealedClassWithInterfaceSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [EmptySealedClassWithInterface]
  */
-object EmptySealedClassWithInterfaceSealedEnum : SealedEnum<EmptySealedClassWithInterface>,
+public object EmptySealedClassWithInterfaceSealedEnum : SealedEnum<EmptySealedClassWithInterface>,
         SealedEnumWithEnumProvider<EmptySealedClassWithInterface,
         EmptySealedClassWithInterfaceEnum>, EnumForSealedEnumProvider<EmptySealedClassWithInterface,
         EmptySealedClassWithInterfaceEnum> {
-    override val values: List<EmptySealedClassWithInterface> = emptyList()
+    public override val values: List<EmptySealedClassWithInterface> = emptyList()
 
 
-    override val enumClass: Class<EmptySealedClassWithInterfaceEnum>
+    public override val enumClass: Class<EmptySealedClassWithInterfaceEnum>
         get() = EmptySealedClassWithInterfaceEnum::class.java
 
-    override fun ordinalOf(obj: EmptySealedClassWithInterface): Int = throw
+    public override fun ordinalOf(obj: EmptySealedClassWithInterface): Int = throw
             AssertionError("Constructing a EmptySealedClassWithInterface is impossible, since it has no sealed subclasses")
 
-    override fun nameOf(obj: EmptySealedClassWithInterface): String = throw
+    public override fun nameOf(obj: EmptySealedClassWithInterface): String = throw
             AssertionError("Constructing a EmptySealedClassWithInterface is impossible, since it has no sealed subclasses")
 
-    override fun valueOf(name: String): EmptySealedClassWithInterface = throw
+    public override fun valueOf(name: String): EmptySealedClassWithInterface = throw
             IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
 
-    override fun sealedObjectToEnum(obj: EmptySealedClassWithInterface):
+    public override fun sealedObjectToEnum(obj: EmptySealedClassWithInterface):
             EmptySealedClassWithInterfaceEnum = throw
             AssertionError("Constructing a EmptySealedClassWithInterface is impossible, since it has no sealed subclasses")
 
-    override fun enumToSealedObject(enum: EmptySealedClassWithInterfaceEnum):
+    public override fun enumToSealedObject(`enum`: EmptySealedClassWithInterfaceEnum):
             EmptySealedClassWithInterface = throw
             AssertionError("Constructing a EmptySealedClassWithInterface is impossible, since it has no sealed subclasses")
 }
@@ -81,25 +81,26 @@ object EmptySealedClassWithInterfaceSealedEnum : SealedEnum<EmptySealedClassWith
 /**
  * The index of [this] in the values list.
  */
-val EmptySealedClassWithInterface.ordinal: Int
+public val EmptySealedClassWithInterface.ordinal: Int
     get() = EmptySealedClassWithInterfaceSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val EmptySealedClassWithInterface.name: String
+public val EmptySealedClassWithInterface.name: String
     get() = EmptySealedClassWithInterfaceSealedEnum.nameOf(this)
 
 /**
  * A list of all [EmptySealedClassWithInterface] objects.
  */
-val EmptySealedClassWithInterface.Companion.values: List<EmptySealedClassWithInterface>
+public val EmptySealedClassWithInterface.Companion.values: List<EmptySealedClassWithInterface>
     get() = EmptySealedClassWithInterfaceSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [EmptySealedClassWithInterface]
  */
-val EmptySealedClassWithInterface.Companion.sealedEnum: EmptySealedClassWithInterfaceSealedEnum
+public val EmptySealedClassWithInterface.Companion.sealedEnum:
+        EmptySealedClassWithInterfaceSealedEnum
     get() = EmptySealedClassWithInterfaceSealedEnum
 
 /**
@@ -108,8 +109,8 @@ val EmptySealedClassWithInterface.Companion.sealedEnum: EmptySealedClassWithInte
  * If the given name doesn't correspond to any [EmptySealedClassWithInterface], an
  * [IllegalArgumentException] will be thrown.
  */
-fun EmptySealedClassWithInterface.Companion.valueOf(name: String): EmptySealedClassWithInterface =
-        EmptySealedClassWithInterfaceSealedEnum.valueOf(name)
+public fun EmptySealedClassWithInterface.Companion.valueOf(name: String):
+        EmptySealedClassWithInterface = EmptySealedClassWithInterfaceSealedEnum.valueOf(name)
 
 """.trimIndent()
 
@@ -135,62 +136,63 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [OneObjectSealedClassWithInterface]
  */
-enum class OneObjectSealedClassWithInterfaceEnum(
+public enum class OneObjectSealedClassWithInterfaceEnum(
     sealedObject: OneObjectSealedClassWithInterface
 ) : TestInterface by sealedObject {
-    OneObjectSealedClassWithInterface_FirstObject(com.livefront.sealedenum.compilation.generics.OneObjectSealedClassWithInterface.FirstObject)
+    OneObjectSealedClassWithInterface_FirstObject(com.livefront.sealedenum.compilation.generics.OneObjectSealedClassWithInterface.FirstObject),
 }
 
 /**
  * The isomorphic [OneObjectSealedClassWithInterfaceEnum] for [this].
  */
-val OneObjectSealedClassWithInterface.enum: OneObjectSealedClassWithInterfaceEnum
+public val OneObjectSealedClassWithInterface.`enum`: OneObjectSealedClassWithInterfaceEnum
     get() = OneObjectSealedClassWithInterfaceSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [OneObjectSealedClassWithInterface] for [this].
  */
-val OneObjectSealedClassWithInterfaceEnum.sealedObject: OneObjectSealedClassWithInterface
+public val OneObjectSealedClassWithInterfaceEnum.sealedObject: OneObjectSealedClassWithInterface
     get() = OneObjectSealedClassWithInterfaceSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [OneObjectSealedClassWithInterface]
  */
-object OneObjectSealedClassWithInterfaceSealedEnum : SealedEnum<OneObjectSealedClassWithInterface>,
+public object OneObjectSealedClassWithInterfaceSealedEnum :
+        SealedEnum<OneObjectSealedClassWithInterface>,
         SealedEnumWithEnumProvider<OneObjectSealedClassWithInterface,
         OneObjectSealedClassWithInterfaceEnum>,
         EnumForSealedEnumProvider<OneObjectSealedClassWithInterface,
         OneObjectSealedClassWithInterfaceEnum> {
-    override val values: List<OneObjectSealedClassWithInterface> = listOf(
+    public override val values: List<OneObjectSealedClassWithInterface> = listOf(
         OneObjectSealedClassWithInterface.FirstObject
     )
 
 
-    override val enumClass: Class<OneObjectSealedClassWithInterfaceEnum>
+    public override val enumClass: Class<OneObjectSealedClassWithInterfaceEnum>
         get() = OneObjectSealedClassWithInterfaceEnum::class.java
 
-    override fun ordinalOf(obj: OneObjectSealedClassWithInterface): Int = when (obj) {
+    public override fun ordinalOf(obj: OneObjectSealedClassWithInterface): Int = when (obj) {
         OneObjectSealedClassWithInterface.FirstObject -> 0
     }
 
-    override fun nameOf(obj: OneObjectSealedClassWithInterface): String = when (obj) {
+    public override fun nameOf(obj: OneObjectSealedClassWithInterface): String = when (obj) {
         OneObjectSealedClassWithInterface.FirstObject ->
                 "OneObjectSealedClassWithInterface_FirstObject"
     }
 
-    override fun valueOf(name: String): OneObjectSealedClassWithInterface = when (name) {
+    public override fun valueOf(name: String): OneObjectSealedClassWithInterface = when (name) {
         "OneObjectSealedClassWithInterface_FirstObject" ->
                 OneObjectSealedClassWithInterface.FirstObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: OneObjectSealedClassWithInterface):
+    public override fun sealedObjectToEnum(obj: OneObjectSealedClassWithInterface):
             OneObjectSealedClassWithInterfaceEnum = when (obj) {
         OneObjectSealedClassWithInterface.FirstObject ->
                 OneObjectSealedClassWithInterfaceEnum.OneObjectSealedClassWithInterface_FirstObject
     }
 
-    override fun enumToSealedObject(enum: OneObjectSealedClassWithInterfaceEnum):
+    public override fun enumToSealedObject(`enum`: OneObjectSealedClassWithInterfaceEnum):
             OneObjectSealedClassWithInterface = when (enum) {
         OneObjectSealedClassWithInterfaceEnum.OneObjectSealedClassWithInterface_FirstObject ->
                 OneObjectSealedClassWithInterface.FirstObject
@@ -200,26 +202,27 @@ object OneObjectSealedClassWithInterfaceSealedEnum : SealedEnum<OneObjectSealedC
 /**
  * The index of [this] in the values list.
  */
-val OneObjectSealedClassWithInterface.ordinal: Int
+public val OneObjectSealedClassWithInterface.ordinal: Int
     get() = OneObjectSealedClassWithInterfaceSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val OneObjectSealedClassWithInterface.name: String
+public val OneObjectSealedClassWithInterface.name: String
     get() = OneObjectSealedClassWithInterfaceSealedEnum.nameOf(this)
 
 /**
  * A list of all [OneObjectSealedClassWithInterface] objects.
  */
-val OneObjectSealedClassWithInterface.Companion.values: List<OneObjectSealedClassWithInterface>
+public val OneObjectSealedClassWithInterface.Companion.values:
+        List<OneObjectSealedClassWithInterface>
     get() = OneObjectSealedClassWithInterfaceSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class
  * [OneObjectSealedClassWithInterface]
  */
-val OneObjectSealedClassWithInterface.Companion.sealedEnum:
+public val OneObjectSealedClassWithInterface.Companion.sealedEnum:
         OneObjectSealedClassWithInterfaceSealedEnum
     get() = OneObjectSealedClassWithInterfaceSealedEnum
 
@@ -229,7 +232,7 @@ val OneObjectSealedClassWithInterface.Companion.sealedEnum:
  * If the given name doesn't correspond to any [OneObjectSealedClassWithInterface], an
  * [IllegalArgumentException] will be thrown.
  */
-fun OneObjectSealedClassWithInterface.Companion.valueOf(name: String):
+public fun OneObjectSealedClassWithInterface.Companion.valueOf(name: String):
         OneObjectSealedClassWithInterface =
         OneObjectSealedClassWithInterfaceSealedEnum.valueOf(name)
 
@@ -258,62 +261,62 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [TwoObjectSealedClassWithGenericInterface]
  */
-enum class TwoObjectSealedClassWithGenericInterfaceEnum(
+public enum class TwoObjectSealedClassWithGenericInterfaceEnum(
     sealedObject: TwoObjectSealedClassWithGenericInterface<TestInterface>
 ) : TestGenericInterface<TestInterface> by sealedObject {
     TwoObjectSealedClassWithGenericInterface_FirstObject(com.livefront.sealedenum.compilation.generics.TwoObjectSealedClassWithGenericInterface.FirstObject),
-
-    TwoObjectSealedClassWithGenericInterface_SecondObject(com.livefront.sealedenum.compilation.generics.TwoObjectSealedClassWithGenericInterface.SecondObject)
+    TwoObjectSealedClassWithGenericInterface_SecondObject(com.livefront.sealedenum.compilation.generics.TwoObjectSealedClassWithGenericInterface.SecondObject),
 }
 
 /**
  * The isomorphic [TwoObjectSealedClassWithGenericInterfaceEnum] for [this].
  */
-val TwoObjectSealedClassWithGenericInterface<TestInterface>.enum:
+public val TwoObjectSealedClassWithGenericInterface<TestInterface>.`enum`:
         TwoObjectSealedClassWithGenericInterfaceEnum
     get() = TwoObjectSealedClassWithGenericInterfaceSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [TwoObjectSealedClassWithGenericInterface] for [this].
  */
-val TwoObjectSealedClassWithGenericInterfaceEnum.sealedObject:
+public val TwoObjectSealedClassWithGenericInterfaceEnum.sealedObject:
         TwoObjectSealedClassWithGenericInterface<TestInterface>
     get() = TwoObjectSealedClassWithGenericInterfaceSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [TwoObjectSealedClassWithGenericInterface]
  */
-object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
+public object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
         SealedEnum<TwoObjectSealedClassWithGenericInterface<TestInterface>>,
         SealedEnumWithEnumProvider<TwoObjectSealedClassWithGenericInterface<TestInterface>,
         TwoObjectSealedClassWithGenericInterfaceEnum>,
         EnumForSealedEnumProvider<TwoObjectSealedClassWithGenericInterface<TestInterface>,
         TwoObjectSealedClassWithGenericInterfaceEnum> {
-    override val values: List<TwoObjectSealedClassWithGenericInterface<TestInterface>> = listOf(
+    public override val values: List<TwoObjectSealedClassWithGenericInterface<TestInterface>> =
+            listOf(
         TwoObjectSealedClassWithGenericInterface.FirstObject,
         TwoObjectSealedClassWithGenericInterface.SecondObject
     )
 
 
-    override val enumClass: Class<TwoObjectSealedClassWithGenericInterfaceEnum>
+    public override val enumClass: Class<TwoObjectSealedClassWithGenericInterfaceEnum>
         get() = TwoObjectSealedClassWithGenericInterfaceEnum::class.java
 
-    override fun ordinalOf(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>): Int = when
-            (obj) {
+    public override fun ordinalOf(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>): Int
+            = when (obj) {
         TwoObjectSealedClassWithGenericInterface.FirstObject -> 0
         TwoObjectSealedClassWithGenericInterface.SecondObject -> 1
     }
 
-    override fun nameOf(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>): String = when
-            (obj) {
+    public override fun nameOf(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>): String
+            = when (obj) {
         TwoObjectSealedClassWithGenericInterface.FirstObject ->
                 "TwoObjectSealedClassWithGenericInterface_FirstObject"
         TwoObjectSealedClassWithGenericInterface.SecondObject ->
                 "TwoObjectSealedClassWithGenericInterface_SecondObject"
     }
 
-    override fun valueOf(name: String): TwoObjectSealedClassWithGenericInterface<TestInterface> =
-            when (name) {
+    public override fun valueOf(name: String):
+            TwoObjectSealedClassWithGenericInterface<TestInterface> = when (name) {
         "TwoObjectSealedClassWithGenericInterface_FirstObject" ->
                 TwoObjectSealedClassWithGenericInterface.FirstObject
         "TwoObjectSealedClassWithGenericInterface_SecondObject" ->
@@ -321,7 +324,8 @@ object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>):
+    public override
+            fun sealedObjectToEnum(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>):
             TwoObjectSealedClassWithGenericInterfaceEnum = when (obj) {
         TwoObjectSealedClassWithGenericInterface.FirstObject ->
                 TwoObjectSealedClassWithGenericInterfaceEnum.TwoObjectSealedClassWithGenericInterface_FirstObject
@@ -329,7 +333,7 @@ object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
                 TwoObjectSealedClassWithGenericInterfaceEnum.TwoObjectSealedClassWithGenericInterface_SecondObject
     }
 
-    override fun enumToSealedObject(enum: TwoObjectSealedClassWithGenericInterfaceEnum):
+    public override fun enumToSealedObject(`enum`: TwoObjectSealedClassWithGenericInterfaceEnum):
             TwoObjectSealedClassWithGenericInterface<TestInterface> = when (enum) {
         TwoObjectSealedClassWithGenericInterfaceEnum.TwoObjectSealedClassWithGenericInterface_FirstObject ->
                 TwoObjectSealedClassWithGenericInterface.FirstObject
@@ -341,19 +345,19 @@ object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
 /**
  * The index of [this] in the values list.
  */
-val TwoObjectSealedClassWithGenericInterface<TestInterface>.ordinal: Int
+public val TwoObjectSealedClassWithGenericInterface<TestInterface>.ordinal: Int
     get() = TwoObjectSealedClassWithGenericInterfaceSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val TwoObjectSealedClassWithGenericInterface<TestInterface>.name: String
+public val TwoObjectSealedClassWithGenericInterface<TestInterface>.name: String
     get() = TwoObjectSealedClassWithGenericInterfaceSealedEnum.nameOf(this)
 
 /**
  * A list of all [TwoObjectSealedClassWithGenericInterface] objects.
  */
-val TwoObjectSealedClassWithGenericInterface.Companion.values:
+public val TwoObjectSealedClassWithGenericInterface.Companion.values:
         List<TwoObjectSealedClassWithGenericInterface<TestInterface>>
     get() = TwoObjectSealedClassWithGenericInterfaceSealedEnum.values
 
@@ -361,7 +365,7 @@ val TwoObjectSealedClassWithGenericInterface.Companion.values:
  * Returns an implementation of [SealedEnum] for the sealed class
  * [TwoObjectSealedClassWithGenericInterface]
  */
-val TwoObjectSealedClassWithGenericInterface.Companion.sealedEnum:
+public val TwoObjectSealedClassWithGenericInterface.Companion.sealedEnum:
         TwoObjectSealedClassWithGenericInterfaceSealedEnum
     get() = TwoObjectSealedClassWithGenericInterfaceSealedEnum
 
@@ -371,7 +375,7 @@ val TwoObjectSealedClassWithGenericInterface.Companion.sealedEnum:
  * If the given name doesn't correspond to any [TwoObjectSealedClassWithGenericInterface], an
  * [IllegalArgumentException] will be thrown.
  */
-fun TwoObjectSealedClassWithGenericInterface.Companion.valueOf(name: String):
+public fun TwoObjectSealedClassWithGenericInterface.Companion.valueOf(name: String):
         TwoObjectSealedClassWithGenericInterface<TestInterface> =
         TwoObjectSealedClassWithGenericInterfaceSealedEnum.valueOf(name)
 
@@ -406,60 +410,60 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [SealedClassWithGetterInterface]
  */
-enum class SealedClassWithGetterInterfaceEnum(
+public enum class SealedClassWithGetterInterfaceEnum(
     sealedObject: SealedClassWithGetterInterface
 ) : TestGetterInterface by sealedObject {
-    SealedClassWithGetterInterface_FirstObject(com.livefront.sealedenum.compilation.generics.SealedClassWithGetterInterface.FirstObject)
+    SealedClassWithGetterInterface_FirstObject(com.livefront.sealedenum.compilation.generics.SealedClassWithGetterInterface.FirstObject),
 }
 
 /**
  * The isomorphic [SealedClassWithGetterInterfaceEnum] for [this].
  */
-val SealedClassWithGetterInterface.enum: SealedClassWithGetterInterfaceEnum
+public val SealedClassWithGetterInterface.`enum`: SealedClassWithGetterInterfaceEnum
     get() = SealedClassWithGetterInterfaceSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [SealedClassWithGetterInterface] for [this].
  */
-val SealedClassWithGetterInterfaceEnum.sealedObject: SealedClassWithGetterInterface
+public val SealedClassWithGetterInterfaceEnum.sealedObject: SealedClassWithGetterInterface
     get() = SealedClassWithGetterInterfaceSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [SealedClassWithGetterInterface]
  */
-object SealedClassWithGetterInterfaceSealedEnum : SealedEnum<SealedClassWithGetterInterface>,
+public object SealedClassWithGetterInterfaceSealedEnum : SealedEnum<SealedClassWithGetterInterface>,
         SealedEnumWithEnumProvider<SealedClassWithGetterInterface,
         SealedClassWithGetterInterfaceEnum>,
         EnumForSealedEnumProvider<SealedClassWithGetterInterface,
         SealedClassWithGetterInterfaceEnum> {
-    override val values: List<SealedClassWithGetterInterface> = listOf(
+    public override val values: List<SealedClassWithGetterInterface> = listOf(
         SealedClassWithGetterInterface.FirstObject
     )
 
 
-    override val enumClass: Class<SealedClassWithGetterInterfaceEnum>
+    public override val enumClass: Class<SealedClassWithGetterInterfaceEnum>
         get() = SealedClassWithGetterInterfaceEnum::class.java
 
-    override fun ordinalOf(obj: SealedClassWithGetterInterface): Int = when (obj) {
+    public override fun ordinalOf(obj: SealedClassWithGetterInterface): Int = when (obj) {
         SealedClassWithGetterInterface.FirstObject -> 0
     }
 
-    override fun nameOf(obj: SealedClassWithGetterInterface): String = when (obj) {
+    public override fun nameOf(obj: SealedClassWithGetterInterface): String = when (obj) {
         SealedClassWithGetterInterface.FirstObject -> "SealedClassWithGetterInterface_FirstObject"
     }
 
-    override fun valueOf(name: String): SealedClassWithGetterInterface = when (name) {
+    public override fun valueOf(name: String): SealedClassWithGetterInterface = when (name) {
         "SealedClassWithGetterInterface_FirstObject" -> SealedClassWithGetterInterface.FirstObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: SealedClassWithGetterInterface):
+    public override fun sealedObjectToEnum(obj: SealedClassWithGetterInterface):
             SealedClassWithGetterInterfaceEnum = when (obj) {
         SealedClassWithGetterInterface.FirstObject ->
                 SealedClassWithGetterInterfaceEnum.SealedClassWithGetterInterface_FirstObject
     }
 
-    override fun enumToSealedObject(enum: SealedClassWithGetterInterfaceEnum):
+    public override fun enumToSealedObject(`enum`: SealedClassWithGetterInterfaceEnum):
             SealedClassWithGetterInterface = when (enum) {
         SealedClassWithGetterInterfaceEnum.SealedClassWithGetterInterface_FirstObject ->
                 SealedClassWithGetterInterface.FirstObject
@@ -469,25 +473,26 @@ object SealedClassWithGetterInterfaceSealedEnum : SealedEnum<SealedClassWithGett
 /**
  * The index of [this] in the values list.
  */
-val SealedClassWithGetterInterface.ordinal: Int
+public val SealedClassWithGetterInterface.ordinal: Int
     get() = SealedClassWithGetterInterfaceSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val SealedClassWithGetterInterface.name: String
+public val SealedClassWithGetterInterface.name: String
     get() = SealedClassWithGetterInterfaceSealedEnum.nameOf(this)
 
 /**
  * A list of all [SealedClassWithGetterInterface] objects.
  */
-val SealedClassWithGetterInterface.Companion.values: List<SealedClassWithGetterInterface>
+public val SealedClassWithGetterInterface.Companion.values: List<SealedClassWithGetterInterface>
     get() = SealedClassWithGetterInterfaceSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [SealedClassWithGetterInterface]
  */
-val SealedClassWithGetterInterface.Companion.sealedEnum: SealedClassWithGetterInterfaceSealedEnum
+public val SealedClassWithGetterInterface.Companion.sealedEnum:
+        SealedClassWithGetterInterfaceSealedEnum
     get() = SealedClassWithGetterInterfaceSealedEnum
 
 /**
@@ -496,7 +501,7 @@ val SealedClassWithGetterInterface.Companion.sealedEnum: SealedClassWithGetterIn
  * If the given name doesn't correspond to any [SealedClassWithGetterInterface], an
  * [IllegalArgumentException] will be thrown.
  */
-fun SealedClassWithGetterInterface.Companion.valueOf(name: String): SealedClassWithGetterInterface =
-        SealedClassWithGetterInterfaceSealedEnum.valueOf(name)
+public fun SealedClassWithGetterInterface.Companion.valueOf(name: String):
+        SealedClassWithGetterInterface = SealedClassWithGetterInterfaceSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
@@ -34,54 +34,56 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [FirstHierarchy.A]
  */
-enum class FirstHierarchy_AEnum {
-    FirstHierarchy_A_B_C
+public enum class FirstHierarchy_AEnum {
+    FirstHierarchy_A_B_C,
 }
 
 /**
  * The isomorphic [FirstHierarchy_AEnum] for [this].
  */
-val FirstHierarchy.A.enum: FirstHierarchy_AEnum
+public val FirstHierarchy.A.`enum`: FirstHierarchy_AEnum
     get() = FirstHierarchy_ASealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [FirstHierarchy.A] for [this].
  */
-val FirstHierarchy_AEnum.sealedObject: FirstHierarchy.A
+public val FirstHierarchy_AEnum.sealedObject: FirstHierarchy.A
     get() = FirstHierarchy_ASealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [FirstHierarchy.A]
  */
-object FirstHierarchy_ASealedEnum : SealedEnum<FirstHierarchy.A>,
+public object FirstHierarchy_ASealedEnum : SealedEnum<FirstHierarchy.A>,
         SealedEnumWithEnumProvider<FirstHierarchy.A, FirstHierarchy_AEnum>,
         EnumForSealedEnumProvider<FirstHierarchy.A, FirstHierarchy_AEnum> {
-    override val values: List<FirstHierarchy.A> = listOf(
+    public override val values: List<FirstHierarchy.A> = listOf(
         FirstHierarchy.A.B.C
     )
 
 
-    override val enumClass: Class<FirstHierarchy_AEnum>
+    public override val enumClass: Class<FirstHierarchy_AEnum>
         get() = FirstHierarchy_AEnum::class.java
 
-    override fun ordinalOf(obj: FirstHierarchy.A): Int = when (obj) {
+    public override fun ordinalOf(obj: FirstHierarchy.A): Int = when (obj) {
         FirstHierarchy.A.B.C -> 0
     }
 
-    override fun nameOf(obj: FirstHierarchy.A): String = when (obj) {
+    public override fun nameOf(obj: FirstHierarchy.A): String = when (obj) {
         FirstHierarchy.A.B.C -> "FirstHierarchy_A_B_C"
     }
 
-    override fun valueOf(name: String): FirstHierarchy.A = when (name) {
+    public override fun valueOf(name: String): FirstHierarchy.A = when (name) {
         "FirstHierarchy_A_B_C" -> FirstHierarchy.A.B.C
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: FirstHierarchy.A): FirstHierarchy_AEnum = when (obj) {
+    public override fun sealedObjectToEnum(obj: FirstHierarchy.A): FirstHierarchy_AEnum = when
+            (obj) {
         FirstHierarchy.A.B.C -> FirstHierarchy_AEnum.FirstHierarchy_A_B_C
     }
 
-    override fun enumToSealedObject(enum: FirstHierarchy_AEnum): FirstHierarchy.A = when (enum) {
+    public override fun enumToSealedObject(`enum`: FirstHierarchy_AEnum): FirstHierarchy.A = when
+            (enum) {
         FirstHierarchy_AEnum.FirstHierarchy_A_B_C -> FirstHierarchy.A.B.C
     }
 }
@@ -89,25 +91,25 @@ object FirstHierarchy_ASealedEnum : SealedEnum<FirstHierarchy.A>,
 /**
  * The index of [this] in the values list.
  */
-val FirstHierarchy.A.ordinal: Int
+public val FirstHierarchy.A.ordinal: Int
     get() = FirstHierarchy_ASealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val FirstHierarchy.A.name: String
+public val FirstHierarchy.A.name: String
     get() = FirstHierarchy_ASealedEnum.nameOf(this)
 
 /**
  * A list of all [FirstHierarchy.A] objects.
  */
-val FirstHierarchy.A.Companion.values: List<FirstHierarchy.A>
+public val FirstHierarchy.A.Companion.values: List<FirstHierarchy.A>
     get() = FirstHierarchy_ASealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [FirstHierarchy.A]
  */
-val FirstHierarchy.A.Companion.sealedEnum: FirstHierarchy_ASealedEnum
+public val FirstHierarchy.A.Companion.sealedEnum: FirstHierarchy_ASealedEnum
     get() = FirstHierarchy_ASealedEnum
 
 /**
@@ -116,7 +118,7 @@ val FirstHierarchy.A.Companion.sealedEnum: FirstHierarchy_ASealedEnum
  * If the given name doesn't correspond to any [FirstHierarchy.A], an [IllegalArgumentException]
  * will be thrown.
  */
-fun FirstHierarchy.A.Companion.valueOf(name: String): FirstHierarchy.A =
+public fun FirstHierarchy.A.Companion.valueOf(name: String): FirstHierarchy.A =
         FirstHierarchy_ASealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -136,55 +138,56 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [FirstHierarchy.A.B]
  */
-enum class FirstHierarchy_A_BEnum {
-    FirstHierarchy_A_B_C
+public enum class FirstHierarchy_A_BEnum {
+    FirstHierarchy_A_B_C,
 }
 
 /**
  * The isomorphic [FirstHierarchy_A_BEnum] for [this].
  */
-val FirstHierarchy.A.B.enum: FirstHierarchy_A_BEnum
+public val FirstHierarchy.A.B.`enum`: FirstHierarchy_A_BEnum
     get() = FirstHierarchy_A_BSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [FirstHierarchy.A.B] for [this].
  */
-val FirstHierarchy_A_BEnum.sealedObject: FirstHierarchy.A.B
+public val FirstHierarchy_A_BEnum.sealedObject: FirstHierarchy.A.B
     get() = FirstHierarchy_A_BSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [FirstHierarchy.A.B]
  */
-object FirstHierarchy_A_BSealedEnum : SealedEnum<FirstHierarchy.A.B>,
+public object FirstHierarchy_A_BSealedEnum : SealedEnum<FirstHierarchy.A.B>,
         SealedEnumWithEnumProvider<FirstHierarchy.A.B, FirstHierarchy_A_BEnum>,
         EnumForSealedEnumProvider<FirstHierarchy.A.B, FirstHierarchy_A_BEnum> {
-    override val values: List<FirstHierarchy.A.B> = listOf(
+    public override val values: List<FirstHierarchy.A.B> = listOf(
         FirstHierarchy.A.B.C
     )
 
 
-    override val enumClass: Class<FirstHierarchy_A_BEnum>
+    public override val enumClass: Class<FirstHierarchy_A_BEnum>
         get() = FirstHierarchy_A_BEnum::class.java
 
-    override fun ordinalOf(obj: FirstHierarchy.A.B): Int = when (obj) {
+    public override fun ordinalOf(obj: FirstHierarchy.A.B): Int = when (obj) {
         FirstHierarchy.A.B.C -> 0
     }
 
-    override fun nameOf(obj: FirstHierarchy.A.B): String = when (obj) {
+    public override fun nameOf(obj: FirstHierarchy.A.B): String = when (obj) {
         FirstHierarchy.A.B.C -> "FirstHierarchy_A_B_C"
     }
 
-    override fun valueOf(name: String): FirstHierarchy.A.B = when (name) {
+    public override fun valueOf(name: String): FirstHierarchy.A.B = when (name) {
         "FirstHierarchy_A_B_C" -> FirstHierarchy.A.B.C
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: FirstHierarchy.A.B): FirstHierarchy_A_BEnum = when (obj) {
+    public override fun sealedObjectToEnum(obj: FirstHierarchy.A.B): FirstHierarchy_A_BEnum = when
+            (obj) {
         FirstHierarchy.A.B.C -> FirstHierarchy_A_BEnum.FirstHierarchy_A_B_C
     }
 
-    override fun enumToSealedObject(enum: FirstHierarchy_A_BEnum): FirstHierarchy.A.B = when
-            (enum) {
+    public override fun enumToSealedObject(`enum`: FirstHierarchy_A_BEnum): FirstHierarchy.A.B =
+            when (enum) {
         FirstHierarchy_A_BEnum.FirstHierarchy_A_B_C -> FirstHierarchy.A.B.C
     }
 }
@@ -192,25 +195,25 @@ object FirstHierarchy_A_BSealedEnum : SealedEnum<FirstHierarchy.A.B>,
 /**
  * The index of [this] in the values list.
  */
-val FirstHierarchy.A.B.ordinal: Int
+public val FirstHierarchy.A.B.ordinal: Int
     get() = FirstHierarchy_A_BSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val FirstHierarchy.A.B.name: String
+public val FirstHierarchy.A.B.name: String
     get() = FirstHierarchy_A_BSealedEnum.nameOf(this)
 
 /**
  * A list of all [FirstHierarchy.A.B] objects.
  */
-val FirstHierarchy.A.B.Companion.values: List<FirstHierarchy.A.B>
+public val FirstHierarchy.A.B.Companion.values: List<FirstHierarchy.A.B>
     get() = FirstHierarchy_A_BSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [FirstHierarchy.A.B]
  */
-val FirstHierarchy.A.B.Companion.sealedEnum: FirstHierarchy_A_BSealedEnum
+public val FirstHierarchy.A.B.Companion.sealedEnum: FirstHierarchy_A_BSealedEnum
     get() = FirstHierarchy_A_BSealedEnum
 
 /**
@@ -219,7 +222,7 @@ val FirstHierarchy.A.B.Companion.sealedEnum: FirstHierarchy_A_BSealedEnum
  * If the given name doesn't correspond to any [FirstHierarchy.A.B], an [IllegalArgumentException]
  * will be thrown.
  */
-fun FirstHierarchy.A.B.Companion.valueOf(name: String): FirstHierarchy.A.B =
+public fun FirstHierarchy.A.B.Companion.valueOf(name: String): FirstHierarchy.A.B =
         FirstHierarchy_A_BSealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -281,8 +284,8 @@ import kotlin.collections.List
 /**
  * An implementation of [SealedEnum] for the sealed class [SecondHierarchy.A]
  */
-object SecondHierarchy_ASealedEnum : SealedEnum<SecondHierarchy.A> {
-    override val values: List<SecondHierarchy.A> = listOf(
+public object SecondHierarchy_ASealedEnum : SealedEnum<SecondHierarchy.A> {
+    public override val values: List<SecondHierarchy.A> = listOf(
         SecondHierarchy.A.B,
         SecondHierarchy.A.C.D,
         SecondHierarchy.A.C.E,
@@ -293,7 +296,7 @@ object SecondHierarchy_ASealedEnum : SealedEnum<SecondHierarchy.A> {
     )
 
 
-    override fun ordinalOf(obj: SecondHierarchy.A): Int = when (obj) {
+    public override fun ordinalOf(obj: SecondHierarchy.A): Int = when (obj) {
         SecondHierarchy.A.B -> 0
         SecondHierarchy.A.C.D -> 1
         SecondHierarchy.A.C.E -> 2
@@ -303,7 +306,7 @@ object SecondHierarchy_ASealedEnum : SealedEnum<SecondHierarchy.A> {
         SecondHierarchy.A.L -> 6
     }
 
-    override fun nameOf(obj: SecondHierarchy.A): String = when (obj) {
+    public override fun nameOf(obj: SecondHierarchy.A): String = when (obj) {
         SecondHierarchy.A.B -> "SecondHierarchy_A_B"
         SecondHierarchy.A.C.D -> "SecondHierarchy_A_C_D"
         SecondHierarchy.A.C.E -> "SecondHierarchy_A_C_E"
@@ -313,7 +316,7 @@ object SecondHierarchy_ASealedEnum : SealedEnum<SecondHierarchy.A> {
         SecondHierarchy.A.L -> "SecondHierarchy_A_L"
     }
 
-    override fun valueOf(name: String): SecondHierarchy.A = when (name) {
+    public override fun valueOf(name: String): SecondHierarchy.A = when (name) {
         "SecondHierarchy_A_B" -> SecondHierarchy.A.B
         "SecondHierarchy_A_C_D" -> SecondHierarchy.A.C.D
         "SecondHierarchy_A_C_E" -> SecondHierarchy.A.C.E
@@ -328,25 +331,25 @@ object SecondHierarchy_ASealedEnum : SealedEnum<SecondHierarchy.A> {
 /**
  * The index of [this] in the values list.
  */
-val SecondHierarchy.A.ordinal: Int
+public val SecondHierarchy.A.ordinal: Int
     get() = SecondHierarchy_ASealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val SecondHierarchy.A.name: String
+public val SecondHierarchy.A.name: String
     get() = SecondHierarchy_ASealedEnum.nameOf(this)
 
 /**
  * A list of all [SecondHierarchy.A] objects.
  */
-val SecondHierarchy.A.Companion.values: List<SecondHierarchy.A>
+public val SecondHierarchy.A.Companion.values: List<SecondHierarchy.A>
     get() = SecondHierarchy_ASealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [SecondHierarchy.A]
  */
-val SecondHierarchy.A.Companion.sealedEnum: SecondHierarchy_ASealedEnum
+public val SecondHierarchy.A.Companion.sealedEnum: SecondHierarchy_ASealedEnum
     get() = SecondHierarchy_ASealedEnum
 
 /**
@@ -355,7 +358,7 @@ val SecondHierarchy.A.Companion.sealedEnum: SecondHierarchy_ASealedEnum
  * If the given name doesn't correspond to any [SecondHierarchy.A], an [IllegalArgumentException]
  * will be thrown.
  */
-fun SecondHierarchy.A.Companion.valueOf(name: String): SecondHierarchy.A =
+public fun SecondHierarchy.A.Companion.valueOf(name: String): SecondHierarchy.A =
         SecondHierarchy_ASealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -372,8 +375,8 @@ import kotlin.collections.List
 /**
  * An implementation of [SealedEnum] for the sealed class [SecondHierarchy.A.C]
  */
-object SecondHierarchy_A_CSealedEnum : SealedEnum<SecondHierarchy.A.C> {
-    override val values: List<SecondHierarchy.A.C> = listOf(
+public object SecondHierarchy_A_CSealedEnum : SealedEnum<SecondHierarchy.A.C> {
+    public override val values: List<SecondHierarchy.A.C> = listOf(
         SecondHierarchy.A.C.D,
         SecondHierarchy.A.C.E,
         SecondHierarchy.A.C.F.G,
@@ -381,21 +384,21 @@ object SecondHierarchy_A_CSealedEnum : SealedEnum<SecondHierarchy.A.C> {
     )
 
 
-    override fun ordinalOf(obj: SecondHierarchy.A.C): Int = when (obj) {
+    public override fun ordinalOf(obj: SecondHierarchy.A.C): Int = when (obj) {
         SecondHierarchy.A.C.D -> 0
         SecondHierarchy.A.C.E -> 1
         SecondHierarchy.A.C.F.G -> 2
         SecondHierarchy.A.C.H.I -> 3
     }
 
-    override fun nameOf(obj: SecondHierarchy.A.C): String = when (obj) {
+    public override fun nameOf(obj: SecondHierarchy.A.C): String = when (obj) {
         SecondHierarchy.A.C.D -> "SecondHierarchy_A_C_D"
         SecondHierarchy.A.C.E -> "SecondHierarchy_A_C_E"
         SecondHierarchy.A.C.F.G -> "SecondHierarchy_A_C_F_G"
         SecondHierarchy.A.C.H.I -> "SecondHierarchy_A_C_H_I"
     }
 
-    override fun valueOf(name: String): SecondHierarchy.A.C = when (name) {
+    public override fun valueOf(name: String): SecondHierarchy.A.C = when (name) {
         "SecondHierarchy_A_C_D" -> SecondHierarchy.A.C.D
         "SecondHierarchy_A_C_E" -> SecondHierarchy.A.C.E
         "SecondHierarchy_A_C_F_G" -> SecondHierarchy.A.C.F.G
@@ -407,25 +410,25 @@ object SecondHierarchy_A_CSealedEnum : SealedEnum<SecondHierarchy.A.C> {
 /**
  * The index of [this] in the values list.
  */
-val SecondHierarchy.A.C.ordinal: Int
+public val SecondHierarchy.A.C.ordinal: Int
     get() = SecondHierarchy_A_CSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val SecondHierarchy.A.C.name: String
+public val SecondHierarchy.A.C.name: String
     get() = SecondHierarchy_A_CSealedEnum.nameOf(this)
 
 /**
  * A list of all [SecondHierarchy.A.C] objects.
  */
-val SecondHierarchy.A.C.Companion.values: List<SecondHierarchy.A.C>
+public val SecondHierarchy.A.C.Companion.values: List<SecondHierarchy.A.C>
     get() = SecondHierarchy_A_CSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [SecondHierarchy.A.C]
  */
-val SecondHierarchy.A.C.Companion.sealedEnum: SecondHierarchy_A_CSealedEnum
+public val SecondHierarchy.A.C.Companion.sealedEnum: SecondHierarchy_A_CSealedEnum
     get() = SecondHierarchy_A_CSealedEnum
 
 /**
@@ -434,7 +437,7 @@ val SecondHierarchy.A.C.Companion.sealedEnum: SecondHierarchy_A_CSealedEnum
  * If the given name doesn't correspond to any [SecondHierarchy.A.C], an [IllegalArgumentException]
  * will be thrown.
  */
-fun SecondHierarchy.A.C.Companion.valueOf(name: String): SecondHierarchy.A.C =
+public fun SecondHierarchy.A.C.Companion.valueOf(name: String): SecondHierarchy.A.C =
         SecondHierarchy_A_CSealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -451,21 +454,21 @@ import kotlin.collections.List
 /**
  * An implementation of [SealedEnum] for the sealed class [SecondHierarchy.A.C.F]
  */
-object SecondHierarchy_A_C_FSealedEnum : SealedEnum<SecondHierarchy.A.C.F> {
-    override val values: List<SecondHierarchy.A.C.F> = listOf(
+public object SecondHierarchy_A_C_FSealedEnum : SealedEnum<SecondHierarchy.A.C.F> {
+    public override val values: List<SecondHierarchy.A.C.F> = listOf(
         SecondHierarchy.A.C.F.G
     )
 
 
-    override fun ordinalOf(obj: SecondHierarchy.A.C.F): Int = when (obj) {
+    public override fun ordinalOf(obj: SecondHierarchy.A.C.F): Int = when (obj) {
         SecondHierarchy.A.C.F.G -> 0
     }
 
-    override fun nameOf(obj: SecondHierarchy.A.C.F): String = when (obj) {
+    public override fun nameOf(obj: SecondHierarchy.A.C.F): String = when (obj) {
         SecondHierarchy.A.C.F.G -> "SecondHierarchy_A_C_F_G"
     }
 
-    override fun valueOf(name: String): SecondHierarchy.A.C.F = when (name) {
+    public override fun valueOf(name: String): SecondHierarchy.A.C.F = when (name) {
         "SecondHierarchy_A_C_F_G" -> SecondHierarchy.A.C.F.G
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
@@ -474,25 +477,25 @@ object SecondHierarchy_A_C_FSealedEnum : SealedEnum<SecondHierarchy.A.C.F> {
 /**
  * The index of [this] in the values list.
  */
-val SecondHierarchy.A.C.F.ordinal: Int
+public val SecondHierarchy.A.C.F.ordinal: Int
     get() = SecondHierarchy_A_C_FSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val SecondHierarchy.A.C.F.name: String
+public val SecondHierarchy.A.C.F.name: String
     get() = SecondHierarchy_A_C_FSealedEnum.nameOf(this)
 
 /**
  * A list of all [SecondHierarchy.A.C.F] objects.
  */
-val SecondHierarchy.A.C.F.Companion.values: List<SecondHierarchy.A.C.F>
+public val SecondHierarchy.A.C.F.Companion.values: List<SecondHierarchy.A.C.F>
     get() = SecondHierarchy_A_C_FSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [SecondHierarchy.A.C.F]
  */
-val SecondHierarchy.A.C.F.Companion.sealedEnum: SecondHierarchy_A_C_FSealedEnum
+public val SecondHierarchy.A.C.F.Companion.sealedEnum: SecondHierarchy_A_C_FSealedEnum
     get() = SecondHierarchy_A_C_FSealedEnum
 
 /**
@@ -501,7 +504,7 @@ val SecondHierarchy.A.C.F.Companion.sealedEnum: SecondHierarchy_A_C_FSealedEnum
  * If the given name doesn't correspond to any [SecondHierarchy.A.C.F], an
  * [IllegalArgumentException] will be thrown.
  */
-fun SecondHierarchy.A.C.F.Companion.valueOf(name: String): SecondHierarchy.A.C.F =
+public fun SecondHierarchy.A.C.F.Companion.valueOf(name: String): SecondHierarchy.A.C.F =
         SecondHierarchy_A_C_FSealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -518,21 +521,21 @@ import kotlin.collections.List
 /**
  * An implementation of [SealedEnum] for the sealed class [SecondHierarchy.A.C.H]
  */
-object SecondHierarchy_A_C_HSealedEnum : SealedEnum<SecondHierarchy.A.C.H> {
-    override val values: List<SecondHierarchy.A.C.H> = listOf(
+public object SecondHierarchy_A_C_HSealedEnum : SealedEnum<SecondHierarchy.A.C.H> {
+    public override val values: List<SecondHierarchy.A.C.H> = listOf(
         SecondHierarchy.A.C.H.I
     )
 
 
-    override fun ordinalOf(obj: SecondHierarchy.A.C.H): Int = when (obj) {
+    public override fun ordinalOf(obj: SecondHierarchy.A.C.H): Int = when (obj) {
         SecondHierarchy.A.C.H.I -> 0
     }
 
-    override fun nameOf(obj: SecondHierarchy.A.C.H): String = when (obj) {
+    public override fun nameOf(obj: SecondHierarchy.A.C.H): String = when (obj) {
         SecondHierarchy.A.C.H.I -> "SecondHierarchy_A_C_H_I"
     }
 
-    override fun valueOf(name: String): SecondHierarchy.A.C.H = when (name) {
+    public override fun valueOf(name: String): SecondHierarchy.A.C.H = when (name) {
         "SecondHierarchy_A_C_H_I" -> SecondHierarchy.A.C.H.I
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
@@ -541,25 +544,25 @@ object SecondHierarchy_A_C_HSealedEnum : SealedEnum<SecondHierarchy.A.C.H> {
 /**
  * The index of [this] in the values list.
  */
-val SecondHierarchy.A.C.H.ordinal: Int
+public val SecondHierarchy.A.C.H.ordinal: Int
     get() = SecondHierarchy_A_C_HSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val SecondHierarchy.A.C.H.name: String
+public val SecondHierarchy.A.C.H.name: String
     get() = SecondHierarchy_A_C_HSealedEnum.nameOf(this)
 
 /**
  * A list of all [SecondHierarchy.A.C.H] objects.
  */
-val SecondHierarchy.A.C.H.Companion.values: List<SecondHierarchy.A.C.H>
+public val SecondHierarchy.A.C.H.Companion.values: List<SecondHierarchy.A.C.H>
     get() = SecondHierarchy_A_C_HSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [SecondHierarchy.A.C.H]
  */
-val SecondHierarchy.A.C.H.Companion.sealedEnum: SecondHierarchy_A_C_HSealedEnum
+public val SecondHierarchy.A.C.H.Companion.sealedEnum: SecondHierarchy_A_C_HSealedEnum
     get() = SecondHierarchy_A_C_HSealedEnum
 
 /**
@@ -568,7 +571,7 @@ val SecondHierarchy.A.C.H.Companion.sealedEnum: SecondHierarchy_A_C_HSealedEnum
  * If the given name doesn't correspond to any [SecondHierarchy.A.C.H], an
  * [IllegalArgumentException] will be thrown.
  */
-fun SecondHierarchy.A.C.H.Companion.valueOf(name: String): SecondHierarchy.A.C.H =
+public fun SecondHierarchy.A.C.H.Companion.valueOf(name: String): SecondHierarchy.A.C.H =
         SecondHierarchy_A_C_HSealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -585,21 +588,21 @@ import kotlin.collections.List
 /**
  * An implementation of [SealedEnum] for the sealed class [SecondHierarchy.A.J]
  */
-object SecondHierarchy_A_JSealedEnum : SealedEnum<SecondHierarchy.A.J> {
-    override val values: List<SecondHierarchy.A.J> = listOf(
+public object SecondHierarchy_A_JSealedEnum : SealedEnum<SecondHierarchy.A.J> {
+    public override val values: List<SecondHierarchy.A.J> = listOf(
         SecondHierarchy.A.J.K
     )
 
 
-    override fun ordinalOf(obj: SecondHierarchy.A.J): Int = when (obj) {
+    public override fun ordinalOf(obj: SecondHierarchy.A.J): Int = when (obj) {
         SecondHierarchy.A.J.K -> 0
     }
 
-    override fun nameOf(obj: SecondHierarchy.A.J): String = when (obj) {
+    public override fun nameOf(obj: SecondHierarchy.A.J): String = when (obj) {
         SecondHierarchy.A.J.K -> "SecondHierarchy_A_J_K"
     }
 
-    override fun valueOf(name: String): SecondHierarchy.A.J = when (name) {
+    public override fun valueOf(name: String): SecondHierarchy.A.J = when (name) {
         "SecondHierarchy_A_J_K" -> SecondHierarchy.A.J.K
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
@@ -608,25 +611,25 @@ object SecondHierarchy_A_JSealedEnum : SealedEnum<SecondHierarchy.A.J> {
 /**
  * The index of [this] in the values list.
  */
-val SecondHierarchy.A.J.ordinal: Int
+public val SecondHierarchy.A.J.ordinal: Int
     get() = SecondHierarchy_A_JSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val SecondHierarchy.A.J.name: String
+public val SecondHierarchy.A.J.name: String
     get() = SecondHierarchy_A_JSealedEnum.nameOf(this)
 
 /**
  * A list of all [SecondHierarchy.A.J] objects.
  */
-val SecondHierarchy.A.J.Companion.values: List<SecondHierarchy.A.J>
+public val SecondHierarchy.A.J.Companion.values: List<SecondHierarchy.A.J>
     get() = SecondHierarchy_A_JSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [SecondHierarchy.A.J]
  */
-val SecondHierarchy.A.J.Companion.sealedEnum: SecondHierarchy_A_JSealedEnum
+public val SecondHierarchy.A.J.Companion.sealedEnum: SecondHierarchy_A_JSealedEnum
     get() = SecondHierarchy_A_JSealedEnum
 
 /**
@@ -635,7 +638,7 @@ val SecondHierarchy.A.J.Companion.sealedEnum: SecondHierarchy_A_JSealedEnum
  * If the given name doesn't correspond to any [SecondHierarchy.A.J], an [IllegalArgumentException]
  * will be thrown.
  */
-fun SecondHierarchy.A.J.Companion.valueOf(name: String): SecondHierarchy.A.J =
+public fun SecondHierarchy.A.J.Companion.valueOf(name: String): SecondHierarchy.A.J =
         SecondHierarchy_A_JSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/kitchensink/JavaBaseClasses.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/kitchensink/JavaBaseClasses.kt
@@ -54,7 +54,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [JavaBaseClassesSealedClass]
  */
-enum class JavaBaseClassesSealedClassEnum(
+public enum class JavaBaseClassesSealedClassEnum(
     sealedObject: JavaBaseClassesSealedClass<*>
 ) : KotlinInterface5<KotlinInterface1> by sealedObject, JavaInterface3<Int> by sealedObject,
         KotlinInterface4<Double> by sealedObject, KotlinInterface6<Int> by sealedObject,
@@ -64,54 +64,53 @@ enum class JavaBaseClassesSealedClassEnum(
         KotlinInterface1 by sealedObject, KotlinInterface3<List<String>> by sealedObject,
         JavaInterface4 by sealedObject {
     JavaBaseClassesSealedClass_FirstObject(com.livefront.sealedenum.compilation.kitchensink.JavaBaseClassesSealedClass.FirstObject),
-
-    JavaBaseClassesSealedClass_SecondObject(com.livefront.sealedenum.compilation.kitchensink.JavaBaseClassesSealedClass.SecondObject)
+    JavaBaseClassesSealedClass_SecondObject(com.livefront.sealedenum.compilation.kitchensink.JavaBaseClassesSealedClass.SecondObject),
 }
 
 /**
  * The isomorphic [JavaBaseClassesSealedClassEnum] for [this].
  */
-val JavaBaseClassesSealedClass<*>.enum: JavaBaseClassesSealedClassEnum
+public val JavaBaseClassesSealedClass<*>.`enum`: JavaBaseClassesSealedClassEnum
     get() = JavaBaseClassesSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [JavaBaseClassesSealedClass] for [this].
  */
-val JavaBaseClassesSealedClassEnum.sealedObject: JavaBaseClassesSealedClass<*>
+public val JavaBaseClassesSealedClassEnum.sealedObject: JavaBaseClassesSealedClass<*>
     get() = JavaBaseClassesSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [JavaBaseClassesSealedClass]
  */
-object JavaBaseClassesSealedClassSealedEnum : SealedEnum<JavaBaseClassesSealedClass<*>>,
+public object JavaBaseClassesSealedClassSealedEnum : SealedEnum<JavaBaseClassesSealedClass<*>>,
         SealedEnumWithEnumProvider<JavaBaseClassesSealedClass<*>, JavaBaseClassesSealedClassEnum>,
         EnumForSealedEnumProvider<JavaBaseClassesSealedClass<*>, JavaBaseClassesSealedClassEnum> {
-    override val values: List<JavaBaseClassesSealedClass<*>> = listOf(
+    public override val values: List<JavaBaseClassesSealedClass<*>> = listOf(
         JavaBaseClassesSealedClass.FirstObject,
         JavaBaseClassesSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<JavaBaseClassesSealedClassEnum>
+    public override val enumClass: Class<JavaBaseClassesSealedClassEnum>
         get() = JavaBaseClassesSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: JavaBaseClassesSealedClass<*>): Int = when (obj) {
+    public override fun ordinalOf(obj: JavaBaseClassesSealedClass<*>): Int = when (obj) {
         JavaBaseClassesSealedClass.FirstObject -> 0
         JavaBaseClassesSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: JavaBaseClassesSealedClass<*>): String = when (obj) {
+    public override fun nameOf(obj: JavaBaseClassesSealedClass<*>): String = when (obj) {
         JavaBaseClassesSealedClass.FirstObject -> "JavaBaseClassesSealedClass_FirstObject"
         JavaBaseClassesSealedClass.SecondObject -> "JavaBaseClassesSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): JavaBaseClassesSealedClass<*> = when (name) {
+    public override fun valueOf(name: String): JavaBaseClassesSealedClass<*> = when (name) {
         "JavaBaseClassesSealedClass_FirstObject" -> JavaBaseClassesSealedClass.FirstObject
         "JavaBaseClassesSealedClass_SecondObject" -> JavaBaseClassesSealedClass.SecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: JavaBaseClassesSealedClass<*>):
+    public override fun sealedObjectToEnum(obj: JavaBaseClassesSealedClass<*>):
             JavaBaseClassesSealedClassEnum = when (obj) {
         JavaBaseClassesSealedClass.FirstObject ->
                 JavaBaseClassesSealedClassEnum.JavaBaseClassesSealedClass_FirstObject
@@ -119,7 +118,7 @@ object JavaBaseClassesSealedClassSealedEnum : SealedEnum<JavaBaseClassesSealedCl
                 JavaBaseClassesSealedClassEnum.JavaBaseClassesSealedClass_SecondObject
     }
 
-    override fun enumToSealedObject(enum: JavaBaseClassesSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: JavaBaseClassesSealedClassEnum):
             JavaBaseClassesSealedClass<*> = when (enum) {
         JavaBaseClassesSealedClassEnum.JavaBaseClassesSealedClass_FirstObject ->
                 JavaBaseClassesSealedClass.FirstObject
@@ -131,25 +130,25 @@ object JavaBaseClassesSealedClassSealedEnum : SealedEnum<JavaBaseClassesSealedCl
 /**
  * The index of [this] in the values list.
  */
-val JavaBaseClassesSealedClass<*>.ordinal: Int
+public val JavaBaseClassesSealedClass<*>.ordinal: Int
     get() = JavaBaseClassesSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val JavaBaseClassesSealedClass<*>.name: String
+public val JavaBaseClassesSealedClass<*>.name: String
     get() = JavaBaseClassesSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [JavaBaseClassesSealedClass] objects.
  */
-val JavaBaseClassesSealedClass.Companion.values: List<JavaBaseClassesSealedClass<*>>
+public val JavaBaseClassesSealedClass.Companion.values: List<JavaBaseClassesSealedClass<*>>
     get() = JavaBaseClassesSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [JavaBaseClassesSealedClass]
  */
-val JavaBaseClassesSealedClass.Companion.sealedEnum: JavaBaseClassesSealedClassSealedEnum
+public val JavaBaseClassesSealedClass.Companion.sealedEnum: JavaBaseClassesSealedClassSealedEnum
     get() = JavaBaseClassesSealedClassSealedEnum
 
 /**
@@ -158,7 +157,7 @@ val JavaBaseClassesSealedClass.Companion.sealedEnum: JavaBaseClassesSealedClassS
  * If the given name doesn't correspond to any [JavaBaseClassesSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun JavaBaseClassesSealedClass.Companion.valueOf(name: String): JavaBaseClassesSealedClass<*> =
-        JavaBaseClassesSealedClassSealedEnum.valueOf(name)
+public fun JavaBaseClassesSealedClass.Companion.valueOf(name: String): JavaBaseClassesSealedClass<*>
+        = JavaBaseClassesSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/location/NestedClass.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/location/NestedClass.kt
@@ -26,27 +26,27 @@ import kotlin.collections.List
 /**
  * An implementation of [SealedEnum] for the sealed class [OuterClass.InsideOneClassSealedClass]
  */
-object OuterClass_InsideOneClassSealedClassSealedEnum :
+public object OuterClass_InsideOneClassSealedClassSealedEnum :
         SealedEnum<OuterClass.InsideOneClassSealedClass> {
-    override val values: List<OuterClass.InsideOneClassSealedClass> = listOf(
+    public override val values: List<OuterClass.InsideOneClassSealedClass> = listOf(
         OuterClass.InsideOneClassSealedClass.FirstObject,
         OuterClass.InsideOneClassSealedClass.SecondObject
     )
 
 
-    override fun ordinalOf(obj: OuterClass.InsideOneClassSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: OuterClass.InsideOneClassSealedClass): Int = when (obj) {
         OuterClass.InsideOneClassSealedClass.FirstObject -> 0
         OuterClass.InsideOneClassSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: OuterClass.InsideOneClassSealedClass): String = when (obj) {
+    public override fun nameOf(obj: OuterClass.InsideOneClassSealedClass): String = when (obj) {
         OuterClass.InsideOneClassSealedClass.FirstObject ->
                 "OuterClass_InsideOneClassSealedClass_FirstObject"
         OuterClass.InsideOneClassSealedClass.SecondObject ->
                 "OuterClass_InsideOneClassSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): OuterClass.InsideOneClassSealedClass = when (name) {
+    public override fun valueOf(name: String): OuterClass.InsideOneClassSealedClass = when (name) {
         "OuterClass_InsideOneClassSealedClass_FirstObject" ->
                 OuterClass.InsideOneClassSealedClass.FirstObject
         "OuterClass_InsideOneClassSealedClass_SecondObject" ->
@@ -58,19 +58,19 @@ object OuterClass_InsideOneClassSealedClassSealedEnum :
 /**
  * The index of [this] in the values list.
  */
-val OuterClass.InsideOneClassSealedClass.ordinal: Int
+public val OuterClass.InsideOneClassSealedClass.ordinal: Int
     get() = OuterClass_InsideOneClassSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val OuterClass.InsideOneClassSealedClass.name: String
+public val OuterClass.InsideOneClassSealedClass.name: String
     get() = OuterClass_InsideOneClassSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [OuterClass.InsideOneClassSealedClass] objects.
  */
-val OuterClass.InsideOneClassSealedClass.Companion.values:
+public val OuterClass.InsideOneClassSealedClass.Companion.values:
         List<OuterClass.InsideOneClassSealedClass>
     get() = OuterClass_InsideOneClassSealedClassSealedEnum.values
 
@@ -78,7 +78,7 @@ val OuterClass.InsideOneClassSealedClass.Companion.values:
  * Returns an implementation of [SealedEnum] for the sealed class
  * [OuterClass.InsideOneClassSealedClass]
  */
-val OuterClass.InsideOneClassSealedClass.Companion.sealedEnum:
+public val OuterClass.InsideOneClassSealedClass.Companion.sealedEnum:
         OuterClass_InsideOneClassSealedClassSealedEnum
     get() = OuterClass_InsideOneClassSealedClassSealedEnum
 
@@ -88,7 +88,7 @@ val OuterClass.InsideOneClassSealedClass.Companion.sealedEnum:
  * If the given name doesn't correspond to any [OuterClass.InsideOneClassSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun OuterClass.InsideOneClassSealedClass.Companion.valueOf(name: String):
+public fun OuterClass.InsideOneClassSealedClass.Companion.valueOf(name: String):
         OuterClass.InsideOneClassSealedClass =
         OuterClass_InsideOneClassSealedClassSealedEnum.valueOf(name)
 
@@ -120,31 +120,32 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class
  * [FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass]
  */
-object FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum :
+public object FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum :
         SealedEnum<FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass> {
-    override val values: List<FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass> =
+    public override val values: List<FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass> =
             listOf(
         FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject,
         FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject
     )
 
 
-    override fun ordinalOf(obj: FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass): Int =
+    public override
+            fun ordinalOf(obj: FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass): Int =
             when (obj) {
         FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject -> 0
         FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass): String =
-            when (obj) {
+    public override fun nameOf(obj: FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass):
+            String = when (obj) {
         FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject ->
                 "FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClass_FirstObject"
         FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject ->
                 "FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass
-            = when (name) {
+    public override fun valueOf(name: String):
+            FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass = when (name) {
         "FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClass_FirstObject" ->
                 FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject
         "FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClass_SecondObject" ->
@@ -156,19 +157,19 @@ object FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum :
 /**
  * The index of [this] in the values list.
  */
-val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.ordinal: Int
+public val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.ordinal: Int
     get() = FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.name: String
+public val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.name: String
     get() = FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass] objects.
  */
-val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.Companion.values:
+public val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.Companion.values:
         List<FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass>
     get() = FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum.values
 
@@ -176,7 +177,7 @@ val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.Companion.value
  * Returns an implementation of [SealedEnum] for the sealed class
  * [FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass]
  */
-val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.Companion.sealedEnum:
+public val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.Companion.sealedEnum:
         FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum
     get() = FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum
 
@@ -188,7 +189,8 @@ val FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.Companion.seale
  * [FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass], an [IllegalArgumentException] will
  * be thrown.
  */
-fun FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.Companion.valueOf(name: String):
+public
+        fun FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.Companion.valueOf(name: String):
         FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass =
         FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum.valueOf(name)
 

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
@@ -25,56 +25,56 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [AlphaOutsideSealedClass]
  */
-enum class AlphaOutsideSealedClassEnum {
-    AlphaFirstObject
+public enum class AlphaOutsideSealedClassEnum {
+    AlphaFirstObject,
 }
 
 /**
  * The isomorphic [AlphaOutsideSealedClassEnum] for [this].
  */
-val AlphaOutsideSealedClass.enum: AlphaOutsideSealedClassEnum
+public val AlphaOutsideSealedClass.`enum`: AlphaOutsideSealedClassEnum
     get() = AlphaOutsideSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [AlphaOutsideSealedClass] for [this].
  */
-val AlphaOutsideSealedClassEnum.sealedObject: AlphaOutsideSealedClass
+public val AlphaOutsideSealedClassEnum.sealedObject: AlphaOutsideSealedClass
     get() = AlphaOutsideSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [AlphaOutsideSealedClass]
  */
-object AlphaOutsideSealedClassSealedEnum : SealedEnum<AlphaOutsideSealedClass>,
+public object AlphaOutsideSealedClassSealedEnum : SealedEnum<AlphaOutsideSealedClass>,
         SealedEnumWithEnumProvider<AlphaOutsideSealedClass, AlphaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<AlphaOutsideSealedClass, AlphaOutsideSealedClassEnum> {
-    override val values: List<AlphaOutsideSealedClass> = listOf(
+    public override val values: List<AlphaOutsideSealedClass> = listOf(
         AlphaFirstObject
     )
 
 
-    override val enumClass: Class<AlphaOutsideSealedClassEnum>
+    public override val enumClass: Class<AlphaOutsideSealedClassEnum>
         get() = AlphaOutsideSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: AlphaOutsideSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: AlphaOutsideSealedClass): Int = when (obj) {
         AlphaFirstObject -> 0
     }
 
-    override fun nameOf(obj: AlphaOutsideSealedClass): String = when (obj) {
+    public override fun nameOf(obj: AlphaOutsideSealedClass): String = when (obj) {
         AlphaFirstObject -> "AlphaFirstObject"
     }
 
-    override fun valueOf(name: String): AlphaOutsideSealedClass = when (name) {
+    public override fun valueOf(name: String): AlphaOutsideSealedClass = when (name) {
         "AlphaFirstObject" -> AlphaFirstObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: AlphaOutsideSealedClass): AlphaOutsideSealedClassEnum =
-            when (obj) {
+    public override fun sealedObjectToEnum(obj: AlphaOutsideSealedClass):
+            AlphaOutsideSealedClassEnum = when (obj) {
         AlphaFirstObject -> AlphaOutsideSealedClassEnum.AlphaFirstObject
     }
 
-    override fun enumToSealedObject(enum: AlphaOutsideSealedClassEnum): AlphaOutsideSealedClass =
-            when (enum) {
+    public override fun enumToSealedObject(`enum`: AlphaOutsideSealedClassEnum):
+            AlphaOutsideSealedClass = when (enum) {
         AlphaOutsideSealedClassEnum.AlphaFirstObject -> AlphaFirstObject
     }
 }
@@ -82,25 +82,25 @@ object AlphaOutsideSealedClassSealedEnum : SealedEnum<AlphaOutsideSealedClass>,
 /**
  * The index of [this] in the values list.
  */
-val AlphaOutsideSealedClass.ordinal: Int
+public val AlphaOutsideSealedClass.ordinal: Int
     get() = AlphaOutsideSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val AlphaOutsideSealedClass.name: String
+public val AlphaOutsideSealedClass.name: String
     get() = AlphaOutsideSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [AlphaOutsideSealedClass] objects.
  */
-val AlphaOutsideSealedClass.Companion.values: List<AlphaOutsideSealedClass>
+public val AlphaOutsideSealedClass.Companion.values: List<AlphaOutsideSealedClass>
     get() = AlphaOutsideSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [AlphaOutsideSealedClass]
  */
-val AlphaOutsideSealedClass.Companion.sealedEnum: AlphaOutsideSealedClassSealedEnum
+public val AlphaOutsideSealedClass.Companion.sealedEnum: AlphaOutsideSealedClassSealedEnum
     get() = AlphaOutsideSealedClassSealedEnum
 
 /**
@@ -109,7 +109,7 @@ val AlphaOutsideSealedClass.Companion.sealedEnum: AlphaOutsideSealedClassSealedE
  * If the given name doesn't correspond to any [AlphaOutsideSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun AlphaOutsideSealedClass.Companion.valueOf(name: String): AlphaOutsideSealedClass =
+public fun AlphaOutsideSealedClass.Companion.valueOf(name: String): AlphaOutsideSealedClass =
         AlphaOutsideSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -138,63 +138,62 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [BetaOutsideSealedClass]
  */
-enum class BetaOutsideSealedClassEnum {
+public enum class BetaOutsideSealedClassEnum {
     BetaFirstObject,
-
-    BetaSecondObject
+    BetaSecondObject,
 }
 
 /**
  * The isomorphic [BetaOutsideSealedClassEnum] for [this].
  */
-val BetaOutsideSealedClass.enum: BetaOutsideSealedClassEnum
+public val BetaOutsideSealedClass.`enum`: BetaOutsideSealedClassEnum
     get() = BetaOutsideSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [BetaOutsideSealedClass] for [this].
  */
-val BetaOutsideSealedClassEnum.sealedObject: BetaOutsideSealedClass
+public val BetaOutsideSealedClassEnum.sealedObject: BetaOutsideSealedClass
     get() = BetaOutsideSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [BetaOutsideSealedClass]
  */
-object BetaOutsideSealedClassSealedEnum : SealedEnum<BetaOutsideSealedClass>,
+public object BetaOutsideSealedClassSealedEnum : SealedEnum<BetaOutsideSealedClass>,
         SealedEnumWithEnumProvider<BetaOutsideSealedClass, BetaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<BetaOutsideSealedClass, BetaOutsideSealedClassEnum> {
-    override val values: List<BetaOutsideSealedClass> = listOf(
+    public override val values: List<BetaOutsideSealedClass> = listOf(
         BetaFirstObject,
         BetaSecondObject
     )
 
 
-    override val enumClass: Class<BetaOutsideSealedClassEnum>
+    public override val enumClass: Class<BetaOutsideSealedClassEnum>
         get() = BetaOutsideSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: BetaOutsideSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: BetaOutsideSealedClass): Int = when (obj) {
         BetaFirstObject -> 0
         BetaSecondObject -> 1
     }
 
-    override fun nameOf(obj: BetaOutsideSealedClass): String = when (obj) {
+    public override fun nameOf(obj: BetaOutsideSealedClass): String = when (obj) {
         BetaFirstObject -> "BetaFirstObject"
         BetaSecondObject -> "BetaSecondObject"
     }
 
-    override fun valueOf(name: String): BetaOutsideSealedClass = when (name) {
+    public override fun valueOf(name: String): BetaOutsideSealedClass = when (name) {
         "BetaFirstObject" -> BetaFirstObject
         "BetaSecondObject" -> BetaSecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: BetaOutsideSealedClass): BetaOutsideSealedClassEnum = when
-            (obj) {
+    public override fun sealedObjectToEnum(obj: BetaOutsideSealedClass): BetaOutsideSealedClassEnum
+            = when (obj) {
         BetaFirstObject -> BetaOutsideSealedClassEnum.BetaFirstObject
         BetaSecondObject -> BetaOutsideSealedClassEnum.BetaSecondObject
     }
 
-    override fun enumToSealedObject(enum: BetaOutsideSealedClassEnum): BetaOutsideSealedClass = when
-            (enum) {
+    public override fun enumToSealedObject(`enum`: BetaOutsideSealedClassEnum):
+            BetaOutsideSealedClass = when (enum) {
         BetaOutsideSealedClassEnum.BetaFirstObject -> BetaFirstObject
         BetaOutsideSealedClassEnum.BetaSecondObject -> BetaSecondObject
     }
@@ -203,25 +202,25 @@ object BetaOutsideSealedClassSealedEnum : SealedEnum<BetaOutsideSealedClass>,
 /**
  * The index of [this] in the values list.
  */
-val BetaOutsideSealedClass.ordinal: Int
+public val BetaOutsideSealedClass.ordinal: Int
     get() = BetaOutsideSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val BetaOutsideSealedClass.name: String
+public val BetaOutsideSealedClass.name: String
     get() = BetaOutsideSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [BetaOutsideSealedClass] objects.
  */
-val BetaOutsideSealedClass.Companion.values: List<BetaOutsideSealedClass>
+public val BetaOutsideSealedClass.Companion.values: List<BetaOutsideSealedClass>
     get() = BetaOutsideSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [BetaOutsideSealedClass]
  */
-val BetaOutsideSealedClass.Companion.sealedEnum: BetaOutsideSealedClassSealedEnum
+public val BetaOutsideSealedClass.Companion.sealedEnum: BetaOutsideSealedClassSealedEnum
     get() = BetaOutsideSealedClassSealedEnum
 
 /**
@@ -230,7 +229,7 @@ val BetaOutsideSealedClass.Companion.sealedEnum: BetaOutsideSealedClassSealedEnu
  * If the given name doesn't correspond to any [BetaOutsideSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun BetaOutsideSealedClass.Companion.valueOf(name: String): BetaOutsideSealedClass =
+public fun BetaOutsideSealedClass.Companion.valueOf(name: String): BetaOutsideSealedClass =
         BetaOutsideSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -262,71 +261,69 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [GammaOutsideSealedClass]
  */
-enum class GammaOutsideSealedClassEnum {
+public enum class GammaOutsideSealedClassEnum {
     GammaFirstObject,
-
     GammaThirdObject,
-
-    GammaOutsideSealedClass_GammaSecondObject
+    GammaOutsideSealedClass_GammaSecondObject,
 }
 
 /**
  * The isomorphic [GammaOutsideSealedClassEnum] for [this].
  */
-val GammaOutsideSealedClass.enum: GammaOutsideSealedClassEnum
+public val GammaOutsideSealedClass.`enum`: GammaOutsideSealedClassEnum
     get() = GammaOutsideSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [GammaOutsideSealedClass] for [this].
  */
-val GammaOutsideSealedClassEnum.sealedObject: GammaOutsideSealedClass
+public val GammaOutsideSealedClassEnum.sealedObject: GammaOutsideSealedClass
     get() = GammaOutsideSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [GammaOutsideSealedClass]
  */
-object GammaOutsideSealedClassSealedEnum : SealedEnum<GammaOutsideSealedClass>,
+public object GammaOutsideSealedClassSealedEnum : SealedEnum<GammaOutsideSealedClass>,
         SealedEnumWithEnumProvider<GammaOutsideSealedClass, GammaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<GammaOutsideSealedClass, GammaOutsideSealedClassEnum> {
-    override val values: List<GammaOutsideSealedClass> = listOf(
+    public override val values: List<GammaOutsideSealedClass> = listOf(
         GammaFirstObject,
         GammaThirdObject,
         GammaOutsideSealedClass.GammaSecondObject
     )
 
 
-    override val enumClass: Class<GammaOutsideSealedClassEnum>
+    public override val enumClass: Class<GammaOutsideSealedClassEnum>
         get() = GammaOutsideSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: GammaOutsideSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: GammaOutsideSealedClass): Int = when (obj) {
         GammaFirstObject -> 0
         GammaThirdObject -> 1
         GammaOutsideSealedClass.GammaSecondObject -> 2
     }
 
-    override fun nameOf(obj: GammaOutsideSealedClass): String = when (obj) {
+    public override fun nameOf(obj: GammaOutsideSealedClass): String = when (obj) {
         GammaFirstObject -> "GammaFirstObject"
         GammaThirdObject -> "GammaThirdObject"
         GammaOutsideSealedClass.GammaSecondObject -> "GammaOutsideSealedClass_GammaSecondObject"
     }
 
-    override fun valueOf(name: String): GammaOutsideSealedClass = when (name) {
+    public override fun valueOf(name: String): GammaOutsideSealedClass = when (name) {
         "GammaFirstObject" -> GammaFirstObject
         "GammaThirdObject" -> GammaThirdObject
         "GammaOutsideSealedClass_GammaSecondObject" -> GammaOutsideSealedClass.GammaSecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: GammaOutsideSealedClass): GammaOutsideSealedClassEnum =
-            when (obj) {
+    public override fun sealedObjectToEnum(obj: GammaOutsideSealedClass):
+            GammaOutsideSealedClassEnum = when (obj) {
         GammaFirstObject -> GammaOutsideSealedClassEnum.GammaFirstObject
         GammaThirdObject -> GammaOutsideSealedClassEnum.GammaThirdObject
         GammaOutsideSealedClass.GammaSecondObject ->
                 GammaOutsideSealedClassEnum.GammaOutsideSealedClass_GammaSecondObject
     }
 
-    override fun enumToSealedObject(enum: GammaOutsideSealedClassEnum): GammaOutsideSealedClass =
-            when (enum) {
+    public override fun enumToSealedObject(`enum`: GammaOutsideSealedClassEnum):
+            GammaOutsideSealedClass = when (enum) {
         GammaOutsideSealedClassEnum.GammaFirstObject -> GammaFirstObject
         GammaOutsideSealedClassEnum.GammaThirdObject -> GammaThirdObject
         GammaOutsideSealedClassEnum.GammaOutsideSealedClass_GammaSecondObject ->
@@ -337,25 +334,25 @@ object GammaOutsideSealedClassSealedEnum : SealedEnum<GammaOutsideSealedClass>,
 /**
  * The index of [this] in the values list.
  */
-val GammaOutsideSealedClass.ordinal: Int
+public val GammaOutsideSealedClass.ordinal: Int
     get() = GammaOutsideSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val GammaOutsideSealedClass.name: String
+public val GammaOutsideSealedClass.name: String
     get() = GammaOutsideSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [GammaOutsideSealedClass] objects.
  */
-val GammaOutsideSealedClass.Companion.values: List<GammaOutsideSealedClass>
+public val GammaOutsideSealedClass.Companion.values: List<GammaOutsideSealedClass>
     get() = GammaOutsideSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [GammaOutsideSealedClass]
  */
-val GammaOutsideSealedClass.Companion.sealedEnum: GammaOutsideSealedClassSealedEnum
+public val GammaOutsideSealedClass.Companion.sealedEnum: GammaOutsideSealedClassSealedEnum
     get() = GammaOutsideSealedClassSealedEnum
 
 /**
@@ -364,7 +361,7 @@ val GammaOutsideSealedClass.Companion.sealedEnum: GammaOutsideSealedClassSealedE
  * If the given name doesn't correspond to any [GammaOutsideSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun GammaOutsideSealedClass.Companion.valueOf(name: String): GammaOutsideSealedClass =
+public fun GammaOutsideSealedClass.Companion.valueOf(name: String): GammaOutsideSealedClass =
         GammaOutsideSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -393,64 +390,63 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [DeltaOutsideSealedClass]
  */
-enum class DeltaOutsideSealedClassEnum {
+public enum class DeltaOutsideSealedClassEnum {
     DeltaObject,
-
-    DeltaOutsideSealedClass_DeltaObject
+    DeltaOutsideSealedClass_DeltaObject,
 }
 
 /**
  * The isomorphic [DeltaOutsideSealedClassEnum] for [this].
  */
-val DeltaOutsideSealedClass.enum: DeltaOutsideSealedClassEnum
+public val DeltaOutsideSealedClass.`enum`: DeltaOutsideSealedClassEnum
     get() = DeltaOutsideSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [DeltaOutsideSealedClass] for [this].
  */
-val DeltaOutsideSealedClassEnum.sealedObject: DeltaOutsideSealedClass
+public val DeltaOutsideSealedClassEnum.sealedObject: DeltaOutsideSealedClass
     get() = DeltaOutsideSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [DeltaOutsideSealedClass]
  */
-object DeltaOutsideSealedClassSealedEnum : SealedEnum<DeltaOutsideSealedClass>,
+public object DeltaOutsideSealedClassSealedEnum : SealedEnum<DeltaOutsideSealedClass>,
         SealedEnumWithEnumProvider<DeltaOutsideSealedClass, DeltaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<DeltaOutsideSealedClass, DeltaOutsideSealedClassEnum> {
-    override val values: List<DeltaOutsideSealedClass> = listOf(
+    public override val values: List<DeltaOutsideSealedClass> = listOf(
         DeltaObject,
         DeltaOutsideSealedClass.DeltaObject
     )
 
 
-    override val enumClass: Class<DeltaOutsideSealedClassEnum>
+    public override val enumClass: Class<DeltaOutsideSealedClassEnum>
         get() = DeltaOutsideSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: DeltaOutsideSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: DeltaOutsideSealedClass): Int = when (obj) {
         DeltaObject -> 0
         DeltaOutsideSealedClass.DeltaObject -> 1
     }
 
-    override fun nameOf(obj: DeltaOutsideSealedClass): String = when (obj) {
+    public override fun nameOf(obj: DeltaOutsideSealedClass): String = when (obj) {
         DeltaObject -> "DeltaObject"
         DeltaOutsideSealedClass.DeltaObject -> "DeltaOutsideSealedClass_DeltaObject"
     }
 
-    override fun valueOf(name: String): DeltaOutsideSealedClass = when (name) {
+    public override fun valueOf(name: String): DeltaOutsideSealedClass = when (name) {
         "DeltaObject" -> DeltaObject
         "DeltaOutsideSealedClass_DeltaObject" -> DeltaOutsideSealedClass.DeltaObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: DeltaOutsideSealedClass): DeltaOutsideSealedClassEnum =
-            when (obj) {
+    public override fun sealedObjectToEnum(obj: DeltaOutsideSealedClass):
+            DeltaOutsideSealedClassEnum = when (obj) {
         DeltaObject -> DeltaOutsideSealedClassEnum.DeltaObject
         DeltaOutsideSealedClass.DeltaObject ->
                 DeltaOutsideSealedClassEnum.DeltaOutsideSealedClass_DeltaObject
     }
 
-    override fun enumToSealedObject(enum: DeltaOutsideSealedClassEnum): DeltaOutsideSealedClass =
-            when (enum) {
+    public override fun enumToSealedObject(`enum`: DeltaOutsideSealedClassEnum):
+            DeltaOutsideSealedClass = when (enum) {
         DeltaOutsideSealedClassEnum.DeltaObject -> DeltaObject
         DeltaOutsideSealedClassEnum.DeltaOutsideSealedClass_DeltaObject ->
                 DeltaOutsideSealedClass.DeltaObject
@@ -460,25 +456,25 @@ object DeltaOutsideSealedClassSealedEnum : SealedEnum<DeltaOutsideSealedClass>,
 /**
  * The index of [this] in the values list.
  */
-val DeltaOutsideSealedClass.ordinal: Int
+public val DeltaOutsideSealedClass.ordinal: Int
     get() = DeltaOutsideSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val DeltaOutsideSealedClass.name: String
+public val DeltaOutsideSealedClass.name: String
     get() = DeltaOutsideSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [DeltaOutsideSealedClass] objects.
  */
-val DeltaOutsideSealedClass.Companion.values: List<DeltaOutsideSealedClass>
+public val DeltaOutsideSealedClass.Companion.values: List<DeltaOutsideSealedClass>
     get() = DeltaOutsideSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [DeltaOutsideSealedClass]
  */
-val DeltaOutsideSealedClass.Companion.sealedEnum: DeltaOutsideSealedClassSealedEnum
+public val DeltaOutsideSealedClass.Companion.sealedEnum: DeltaOutsideSealedClassSealedEnum
     get() = DeltaOutsideSealedClassSealedEnum
 
 /**
@@ -487,7 +483,7 @@ val DeltaOutsideSealedClass.Companion.sealedEnum: DeltaOutsideSealedClassSealedE
  * If the given name doesn't correspond to any [DeltaOutsideSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun DeltaOutsideSealedClass.Companion.valueOf(name: String): DeltaOutsideSealedClass =
+public fun DeltaOutsideSealedClass.Companion.valueOf(name: String): DeltaOutsideSealedClass =
         DeltaOutsideSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
@@ -74,54 +74,41 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [Tree]
  */
-enum class TreeLevelOrderEnum {
+public enum class TreeLevelOrderEnum {
     Tree_A,
-
     Tree_K,
-
     Tree_T,
-
     Tree_L_S,
-
     Tree_B_C_D,
-
     Tree_B_C_E,
-
     Tree_B_C_J,
-
     Tree_L_M_N,
-
     Tree_L_M_O,
-
     Tree_L_P_Q,
-
     Tree_L_P_R,
-
     Tree_B_C_F_G,
-
     Tree_B_C_F_H,
-
-    Tree_B_C_F_I
+    Tree_B_C_F_I,
 }
 
 /**
  * The isomorphic [TreeLevelOrderEnum] for [this].
  */
-val Tree.levelOrderEnum: TreeLevelOrderEnum
+public val Tree.levelOrderEnum: TreeLevelOrderEnum
     get() = TreeLevelOrderSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [Tree] for [this].
  */
-val TreeLevelOrderEnum.sealedObject: Tree
+public val TreeLevelOrderEnum.sealedObject: Tree
     get() = TreeLevelOrderSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [Tree]
  */
-object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
+public object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
         TreeLevelOrderEnum>, EnumForSealedEnumProvider<Tree, TreeLevelOrderEnum> {
-    override val values: List<Tree> = listOf(
+    public override val values: List<Tree> = listOf(
         Tree.A,
         Tree.K,
         Tree.T,
@@ -139,10 +126,10 @@ object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<T
     )
 
 
-    override val enumClass: Class<TreeLevelOrderEnum>
+    public override val enumClass: Class<TreeLevelOrderEnum>
         get() = TreeLevelOrderEnum::class.java
 
-    override fun ordinalOf(obj: Tree): Int = when (obj) {
+    public override fun ordinalOf(obj: Tree): Int = when (obj) {
         Tree.A -> 0
         Tree.K -> 1
         Tree.T -> 2
@@ -159,7 +146,7 @@ object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<T
         Tree.B.C.F.I -> 13
     }
 
-    override fun nameOf(obj: Tree): String = when (obj) {
+    public override fun nameOf(obj: Tree): String = when (obj) {
         Tree.A -> "Tree_A"
         Tree.K -> "Tree_K"
         Tree.T -> "Tree_T"
@@ -176,7 +163,7 @@ object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<T
         Tree.B.C.F.I -> "Tree_B_C_F_I"
     }
 
-    override fun valueOf(name: String): Tree = when (name) {
+    public override fun valueOf(name: String): Tree = when (name) {
         "Tree_A" -> Tree.A
         "Tree_K" -> Tree.K
         "Tree_T" -> Tree.T
@@ -194,7 +181,7 @@ object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<T
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: Tree): TreeLevelOrderEnum = when (obj) {
+    public override fun sealedObjectToEnum(obj: Tree): TreeLevelOrderEnum = when (obj) {
         Tree.A -> TreeLevelOrderEnum.Tree_A
         Tree.K -> TreeLevelOrderEnum.Tree_K
         Tree.T -> TreeLevelOrderEnum.Tree_T
@@ -211,7 +198,7 @@ object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<T
         Tree.B.C.F.I -> TreeLevelOrderEnum.Tree_B_C_F_I
     }
 
-    override fun enumToSealedObject(enum: TreeLevelOrderEnum): Tree = when (enum) {
+    public override fun enumToSealedObject(`enum`: TreeLevelOrderEnum): Tree = when (enum) {
         TreeLevelOrderEnum.Tree_A -> Tree.A
         TreeLevelOrderEnum.Tree_K -> Tree.K
         TreeLevelOrderEnum.Tree_T -> Tree.T
@@ -232,25 +219,25 @@ object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<T
 /**
  * The index of [this] in the values list.
  */
-val Tree.levelOrderOrdinal: Int
+public val Tree.levelOrderOrdinal: Int
     get() = TreeLevelOrderSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val Tree.levelOrderName: String
+public val Tree.levelOrderName: String
     get() = TreeLevelOrderSealedEnum.nameOf(this)
 
 /**
  * A list of all [Tree] objects.
  */
-val Tree.Companion.levelOrderValues: List<Tree>
+public val Tree.Companion.levelOrderValues: List<Tree>
     get() = TreeLevelOrderSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [Tree]
  */
-val Tree.Companion.levelOrderSealedEnum: TreeLevelOrderSealedEnum
+public val Tree.Companion.levelOrderSealedEnum: TreeLevelOrderSealedEnum
     get() = TreeLevelOrderSealedEnum
 
 /**
@@ -258,59 +245,47 @@ val Tree.Companion.levelOrderSealedEnum: TreeLevelOrderSealedEnum
  *
  * If the given name doesn't correspond to any [Tree], an [IllegalArgumentException] will be thrown.
  */
-fun Tree.Companion.levelOrderValueOf(name: String): Tree = TreeLevelOrderSealedEnum.valueOf(name)
+public fun Tree.Companion.levelOrderValueOf(name: String): Tree =
+        TreeLevelOrderSealedEnum.valueOf(name)
 
 /**
  * An isomorphic enum for the sealed class [Tree]
  */
-enum class TreePostOrderEnum {
+public enum class TreePostOrderEnum {
     Tree_B_C_F_G,
-
     Tree_B_C_F_H,
-
     Tree_B_C_F_I,
-
     Tree_B_C_D,
-
     Tree_B_C_E,
-
     Tree_B_C_J,
-
     Tree_L_M_N,
-
     Tree_L_M_O,
-
     Tree_L_P_Q,
-
     Tree_L_P_R,
-
     Tree_L_S,
-
     Tree_A,
-
     Tree_K,
-
-    Tree_T
+    Tree_T,
 }
 
 /**
  * The isomorphic [TreePostOrderEnum] for [this].
  */
-val Tree.postOrderEnum: TreePostOrderEnum
+public val Tree.postOrderEnum: TreePostOrderEnum
     get() = TreePostOrderSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [Tree] for [this].
  */
-val TreePostOrderEnum.sealedObject: Tree
+public val TreePostOrderEnum.sealedObject: Tree
     get() = TreePostOrderSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [Tree]
  */
-object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
+public object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
         TreePostOrderEnum>, EnumForSealedEnumProvider<Tree, TreePostOrderEnum> {
-    override val values: List<Tree> = listOf(
+    public override val values: List<Tree> = listOf(
         Tree.B.C.F.G,
         Tree.B.C.F.H,
         Tree.B.C.F.I,
@@ -328,10 +303,10 @@ object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tr
     )
 
 
-    override val enumClass: Class<TreePostOrderEnum>
+    public override val enumClass: Class<TreePostOrderEnum>
         get() = TreePostOrderEnum::class.java
 
-    override fun ordinalOf(obj: Tree): Int = when (obj) {
+    public override fun ordinalOf(obj: Tree): Int = when (obj) {
         Tree.B.C.F.G -> 0
         Tree.B.C.F.H -> 1
         Tree.B.C.F.I -> 2
@@ -348,7 +323,7 @@ object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tr
         Tree.T -> 13
     }
 
-    override fun nameOf(obj: Tree): String = when (obj) {
+    public override fun nameOf(obj: Tree): String = when (obj) {
         Tree.B.C.F.G -> "Tree_B_C_F_G"
         Tree.B.C.F.H -> "Tree_B_C_F_H"
         Tree.B.C.F.I -> "Tree_B_C_F_I"
@@ -365,7 +340,7 @@ object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tr
         Tree.T -> "Tree_T"
     }
 
-    override fun valueOf(name: String): Tree = when (name) {
+    public override fun valueOf(name: String): Tree = when (name) {
         "Tree_B_C_F_G" -> Tree.B.C.F.G
         "Tree_B_C_F_H" -> Tree.B.C.F.H
         "Tree_B_C_F_I" -> Tree.B.C.F.I
@@ -383,7 +358,7 @@ object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tr
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: Tree): TreePostOrderEnum = when (obj) {
+    public override fun sealedObjectToEnum(obj: Tree): TreePostOrderEnum = when (obj) {
         Tree.B.C.F.G -> TreePostOrderEnum.Tree_B_C_F_G
         Tree.B.C.F.H -> TreePostOrderEnum.Tree_B_C_F_H
         Tree.B.C.F.I -> TreePostOrderEnum.Tree_B_C_F_I
@@ -400,7 +375,7 @@ object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tr
         Tree.T -> TreePostOrderEnum.Tree_T
     }
 
-    override fun enumToSealedObject(enum: TreePostOrderEnum): Tree = when (enum) {
+    public override fun enumToSealedObject(`enum`: TreePostOrderEnum): Tree = when (enum) {
         TreePostOrderEnum.Tree_B_C_F_G -> Tree.B.C.F.G
         TreePostOrderEnum.Tree_B_C_F_H -> Tree.B.C.F.H
         TreePostOrderEnum.Tree_B_C_F_I -> Tree.B.C.F.I
@@ -421,25 +396,25 @@ object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tr
 /**
  * The index of [this] in the values list.
  */
-val Tree.postOrderOrdinal: Int
+public val Tree.postOrderOrdinal: Int
     get() = TreePostOrderSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val Tree.postOrderName: String
+public val Tree.postOrderName: String
     get() = TreePostOrderSealedEnum.nameOf(this)
 
 /**
  * A list of all [Tree] objects.
  */
-val Tree.Companion.postOrderValues: List<Tree>
+public val Tree.Companion.postOrderValues: List<Tree>
     get() = TreePostOrderSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [Tree]
  */
-val Tree.Companion.postOrderSealedEnum: TreePostOrderSealedEnum
+public val Tree.Companion.postOrderSealedEnum: TreePostOrderSealedEnum
     get() = TreePostOrderSealedEnum
 
 /**
@@ -447,59 +422,47 @@ val Tree.Companion.postOrderSealedEnum: TreePostOrderSealedEnum
  *
  * If the given name doesn't correspond to any [Tree], an [IllegalArgumentException] will be thrown.
  */
-fun Tree.Companion.postOrderValueOf(name: String): Tree = TreePostOrderSealedEnum.valueOf(name)
+public fun Tree.Companion.postOrderValueOf(name: String): Tree =
+        TreePostOrderSealedEnum.valueOf(name)
 
 /**
  * An isomorphic enum for the sealed class [Tree]
  */
-enum class TreeInOrderEnum {
+public enum class TreeInOrderEnum {
     Tree_A,
-
     Tree_B_C_D,
-
     Tree_B_C_E,
-
     Tree_B_C_F_G,
-
     Tree_B_C_F_H,
-
     Tree_B_C_F_I,
-
     Tree_B_C_J,
-
     Tree_K,
-
     Tree_L_M_N,
-
     Tree_L_M_O,
-
     Tree_L_P_Q,
-
     Tree_L_P_R,
-
     Tree_L_S,
-
-    Tree_T
+    Tree_T,
 }
 
 /**
  * The isomorphic [TreeInOrderEnum] for [this].
  */
-val Tree.inOrderEnum: TreeInOrderEnum
+public val Tree.inOrderEnum: TreeInOrderEnum
     get() = TreeInOrderSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [Tree] for [this].
  */
-val TreeInOrderEnum.sealedObject: Tree
+public val TreeInOrderEnum.sealedObject: Tree
     get() = TreeInOrderSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [Tree]
  */
-object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree, TreeInOrderEnum>,
-        EnumForSealedEnumProvider<Tree, TreeInOrderEnum> {
-    override val values: List<Tree> = listOf(
+public object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
+        TreeInOrderEnum>, EnumForSealedEnumProvider<Tree, TreeInOrderEnum> {
+    public override val values: List<Tree> = listOf(
         Tree.A,
         Tree.B.C.D,
         Tree.B.C.E,
@@ -517,10 +480,10 @@ object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree
     )
 
 
-    override val enumClass: Class<TreeInOrderEnum>
+    public override val enumClass: Class<TreeInOrderEnum>
         get() = TreeInOrderEnum::class.java
 
-    override fun ordinalOf(obj: Tree): Int = when (obj) {
+    public override fun ordinalOf(obj: Tree): Int = when (obj) {
         Tree.A -> 0
         Tree.B.C.D -> 1
         Tree.B.C.E -> 2
@@ -537,7 +500,7 @@ object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree
         Tree.T -> 13
     }
 
-    override fun nameOf(obj: Tree): String = when (obj) {
+    public override fun nameOf(obj: Tree): String = when (obj) {
         Tree.A -> "Tree_A"
         Tree.B.C.D -> "Tree_B_C_D"
         Tree.B.C.E -> "Tree_B_C_E"
@@ -554,7 +517,7 @@ object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree
         Tree.T -> "Tree_T"
     }
 
-    override fun valueOf(name: String): Tree = when (name) {
+    public override fun valueOf(name: String): Tree = when (name) {
         "Tree_A" -> Tree.A
         "Tree_B_C_D" -> Tree.B.C.D
         "Tree_B_C_E" -> Tree.B.C.E
@@ -572,7 +535,7 @@ object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: Tree): TreeInOrderEnum = when (obj) {
+    public override fun sealedObjectToEnum(obj: Tree): TreeInOrderEnum = when (obj) {
         Tree.A -> TreeInOrderEnum.Tree_A
         Tree.B.C.D -> TreeInOrderEnum.Tree_B_C_D
         Tree.B.C.E -> TreeInOrderEnum.Tree_B_C_E
@@ -589,7 +552,7 @@ object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree
         Tree.T -> TreeInOrderEnum.Tree_T
     }
 
-    override fun enumToSealedObject(enum: TreeInOrderEnum): Tree = when (enum) {
+    public override fun enumToSealedObject(`enum`: TreeInOrderEnum): Tree = when (enum) {
         TreeInOrderEnum.Tree_A -> Tree.A
         TreeInOrderEnum.Tree_B_C_D -> Tree.B.C.D
         TreeInOrderEnum.Tree_B_C_E -> Tree.B.C.E
@@ -610,25 +573,25 @@ object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree
 /**
  * The index of [this] in the values list.
  */
-val Tree.inOrderOrdinal: Int
+public val Tree.inOrderOrdinal: Int
     get() = TreeInOrderSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val Tree.inOrderName: String
+public val Tree.inOrderName: String
     get() = TreeInOrderSealedEnum.nameOf(this)
 
 /**
  * A list of all [Tree] objects.
  */
-val Tree.Companion.inOrderValues: List<Tree>
+public val Tree.Companion.inOrderValues: List<Tree>
     get() = TreeInOrderSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [Tree]
  */
-val Tree.Companion.inOrderSealedEnum: TreeInOrderSealedEnum
+public val Tree.Companion.inOrderSealedEnum: TreeInOrderSealedEnum
     get() = TreeInOrderSealedEnum
 
 /**
@@ -636,59 +599,46 @@ val Tree.Companion.inOrderSealedEnum: TreeInOrderSealedEnum
  *
  * If the given name doesn't correspond to any [Tree], an [IllegalArgumentException] will be thrown.
  */
-fun Tree.Companion.inOrderValueOf(name: String): Tree = TreeInOrderSealedEnum.valueOf(name)
+public fun Tree.Companion.inOrderValueOf(name: String): Tree = TreeInOrderSealedEnum.valueOf(name)
 
 /**
  * An isomorphic enum for the sealed class [Tree]
  */
-enum class TreePreOrderEnum {
+public enum class TreePreOrderEnum {
     Tree_A,
-
     Tree_K,
-
     Tree_T,
-
     Tree_B_C_D,
-
     Tree_B_C_E,
-
     Tree_B_C_J,
-
     Tree_B_C_F_G,
-
     Tree_B_C_F_H,
-
     Tree_B_C_F_I,
-
     Tree_L_S,
-
     Tree_L_M_N,
-
     Tree_L_M_O,
-
     Tree_L_P_Q,
-
-    Tree_L_P_R
+    Tree_L_P_R,
 }
 
 /**
  * The isomorphic [TreePreOrderEnum] for [this].
  */
-val Tree.preOrderEnum: TreePreOrderEnum
+public val Tree.preOrderEnum: TreePreOrderEnum
     get() = TreePreOrderSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [Tree] for [this].
  */
-val TreePreOrderEnum.sealedObject: Tree
+public val TreePreOrderEnum.sealedObject: Tree
     get() = TreePreOrderSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [Tree]
  */
-object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
+public object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
         TreePreOrderEnum>, EnumForSealedEnumProvider<Tree, TreePreOrderEnum> {
-    override val values: List<Tree> = listOf(
+    public override val values: List<Tree> = listOf(
         Tree.A,
         Tree.K,
         Tree.T,
@@ -706,10 +656,10 @@ object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tre
     )
 
 
-    override val enumClass: Class<TreePreOrderEnum>
+    public override val enumClass: Class<TreePreOrderEnum>
         get() = TreePreOrderEnum::class.java
 
-    override fun ordinalOf(obj: Tree): Int = when (obj) {
+    public override fun ordinalOf(obj: Tree): Int = when (obj) {
         Tree.A -> 0
         Tree.K -> 1
         Tree.T -> 2
@@ -726,7 +676,7 @@ object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tre
         Tree.L.P.R -> 13
     }
 
-    override fun nameOf(obj: Tree): String = when (obj) {
+    public override fun nameOf(obj: Tree): String = when (obj) {
         Tree.A -> "Tree_A"
         Tree.K -> "Tree_K"
         Tree.T -> "Tree_T"
@@ -743,7 +693,7 @@ object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tre
         Tree.L.P.R -> "Tree_L_P_R"
     }
 
-    override fun valueOf(name: String): Tree = when (name) {
+    public override fun valueOf(name: String): Tree = when (name) {
         "Tree_A" -> Tree.A
         "Tree_K" -> Tree.K
         "Tree_T" -> Tree.T
@@ -761,7 +711,7 @@ object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tre
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: Tree): TreePreOrderEnum = when (obj) {
+    public override fun sealedObjectToEnum(obj: Tree): TreePreOrderEnum = when (obj) {
         Tree.A -> TreePreOrderEnum.Tree_A
         Tree.K -> TreePreOrderEnum.Tree_K
         Tree.T -> TreePreOrderEnum.Tree_T
@@ -778,7 +728,7 @@ object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tre
         Tree.L.P.R -> TreePreOrderEnum.Tree_L_P_R
     }
 
-    override fun enumToSealedObject(enum: TreePreOrderEnum): Tree = when (enum) {
+    public override fun enumToSealedObject(`enum`: TreePreOrderEnum): Tree = when (enum) {
         TreePreOrderEnum.Tree_A -> Tree.A
         TreePreOrderEnum.Tree_K -> Tree.K
         TreePreOrderEnum.Tree_T -> Tree.T
@@ -799,25 +749,25 @@ object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tre
 /**
  * The index of [this] in the values list.
  */
-val Tree.preOrderOrdinal: Int
+public val Tree.preOrderOrdinal: Int
     get() = TreePreOrderSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val Tree.preOrderName: String
+public val Tree.preOrderName: String
     get() = TreePreOrderSealedEnum.nameOf(this)
 
 /**
  * A list of all [Tree] objects.
  */
-val Tree.Companion.preOrderValues: List<Tree>
+public val Tree.Companion.preOrderValues: List<Tree>
     get() = TreePreOrderSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [Tree]
  */
-val Tree.Companion.preOrderSealedEnum: TreePreOrderSealedEnum
+public val Tree.Companion.preOrderSealedEnum: TreePreOrderSealedEnum
     get() = TreePreOrderSealedEnum
 
 /**
@@ -825,6 +775,6 @@ val Tree.Companion.preOrderSealedEnum: TreePreOrderSealedEnum
  *
  * If the given name doesn't correspond to any [Tree], an [IllegalArgumentException] will be thrown.
  */
-fun Tree.Companion.preOrderValueOf(name: String): Tree = TreePreOrderSealedEnum.valueOf(name)
+public fun Tree.Companion.preOrderValueOf(name: String): Tree = TreePreOrderSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnum.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnum.kt
@@ -50,36 +50,34 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [Environments]
  */
-enum class EnvironmentsEnum(
+public enum class EnvironmentsEnum(
     sealedObject: Environments
 ) : Uri by sealedObject {
     Environments_Http_Livefront(com.livefront.sealedenum.compilation.usecases.Environments.Http.Livefront),
-
     Environments_Http_Google(com.livefront.sealedenum.compilation.usecases.Environments.Http.Google),
-
     Environments_Https_Livefront(com.livefront.sealedenum.compilation.usecases.Environments.Https.Livefront),
-
-    Environments_Https_Google(com.livefront.sealedenum.compilation.usecases.Environments.Https.Google)
+    Environments_Https_Google(com.livefront.sealedenum.compilation.usecases.Environments.Https.Google),
 }
 
 /**
  * The isomorphic [EnvironmentsEnum] for [this].
  */
-val Environments.enum: EnvironmentsEnum
+public val Environments.`enum`: EnvironmentsEnum
     get() = EnvironmentsSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [Environments] for [this].
  */
-val EnvironmentsEnum.sealedObject: Environments
+public val EnvironmentsEnum.sealedObject: Environments
     get() = EnvironmentsSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [Environments]
  */
-object EnvironmentsSealedEnum : SealedEnum<Environments>, SealedEnumWithEnumProvider<Environments,
-        EnvironmentsEnum>, EnumForSealedEnumProvider<Environments, EnvironmentsEnum> {
-    override val values: List<Environments> = listOf(
+public object EnvironmentsSealedEnum : SealedEnum<Environments>,
+        SealedEnumWithEnumProvider<Environments, EnvironmentsEnum>,
+        EnumForSealedEnumProvider<Environments, EnvironmentsEnum> {
+    public override val values: List<Environments> = listOf(
         Environments.Http.Livefront,
         Environments.Http.Google,
         Environments.Https.Livefront,
@@ -87,24 +85,24 @@ object EnvironmentsSealedEnum : SealedEnum<Environments>, SealedEnumWithEnumProv
     )
 
 
-    override val enumClass: Class<EnvironmentsEnum>
+    public override val enumClass: Class<EnvironmentsEnum>
         get() = EnvironmentsEnum::class.java
 
-    override fun ordinalOf(obj: Environments): Int = when (obj) {
+    public override fun ordinalOf(obj: Environments): Int = when (obj) {
         Environments.Http.Livefront -> 0
         Environments.Http.Google -> 1
         Environments.Https.Livefront -> 2
         Environments.Https.Google -> 3
     }
 
-    override fun nameOf(obj: Environments): String = when (obj) {
+    public override fun nameOf(obj: Environments): String = when (obj) {
         Environments.Http.Livefront -> "Environments_Http_Livefront"
         Environments.Http.Google -> "Environments_Http_Google"
         Environments.Https.Livefront -> "Environments_Https_Livefront"
         Environments.Https.Google -> "Environments_Https_Google"
     }
 
-    override fun valueOf(name: String): Environments = when (name) {
+    public override fun valueOf(name: String): Environments = when (name) {
         "Environments_Http_Livefront" -> Environments.Http.Livefront
         "Environments_Http_Google" -> Environments.Http.Google
         "Environments_Https_Livefront" -> Environments.Https.Livefront
@@ -112,14 +110,14 @@ object EnvironmentsSealedEnum : SealedEnum<Environments>, SealedEnumWithEnumProv
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: Environments): EnvironmentsEnum = when (obj) {
+    public override fun sealedObjectToEnum(obj: Environments): EnvironmentsEnum = when (obj) {
         Environments.Http.Livefront -> EnvironmentsEnum.Environments_Http_Livefront
         Environments.Http.Google -> EnvironmentsEnum.Environments_Http_Google
         Environments.Https.Livefront -> EnvironmentsEnum.Environments_Https_Livefront
         Environments.Https.Google -> EnvironmentsEnum.Environments_Https_Google
     }
 
-    override fun enumToSealedObject(enum: EnvironmentsEnum): Environments = when (enum) {
+    public override fun enumToSealedObject(`enum`: EnvironmentsEnum): Environments = when (enum) {
         EnvironmentsEnum.Environments_Http_Livefront -> Environments.Http.Livefront
         EnvironmentsEnum.Environments_Http_Google -> Environments.Http.Google
         EnvironmentsEnum.Environments_Https_Livefront -> Environments.Https.Livefront
@@ -130,25 +128,25 @@ object EnvironmentsSealedEnum : SealedEnum<Environments>, SealedEnumWithEnumProv
 /**
  * The index of [this] in the values list.
  */
-val Environments.ordinal: Int
+public val Environments.ordinal: Int
     get() = EnvironmentsSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val Environments.name: String
+public val Environments.name: String
     get() = EnvironmentsSealedEnum.nameOf(this)
 
 /**
  * A list of all [Environments] objects.
  */
-val Environments.Companion.values: List<Environments>
+public val Environments.Companion.values: List<Environments>
     get() = EnvironmentsSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [Environments]
  */
-val Environments.Companion.sealedEnum: EnvironmentsSealedEnum
+public val Environments.Companion.sealedEnum: EnvironmentsSealedEnum
     get() = EnvironmentsSealedEnum
 
 /**
@@ -157,7 +155,7 @@ val Environments.Companion.sealedEnum: EnvironmentsSealedEnum
  * If the given name doesn't correspond to any [Environments], an [IllegalArgumentException] will be
  * thrown.
  */
-fun Environments.Companion.valueOf(name: String): Environments =
+public fun Environments.Companion.valueOf(name: String): Environments =
         EnvironmentsSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/visibility/NonVisibleInterfaces.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/visibility/NonVisibleInterfaces.kt
@@ -31,56 +31,55 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [PrivateInterfaceSealedClass]
  */
-enum class PrivateInterfaceSealedClassEnum {
+public enum class PrivateInterfaceSealedClassEnum {
     PrivateInterfaceSealedClass_FirstObject,
-
-    PrivateInterfaceSealedClass_SecondObject
+    PrivateInterfaceSealedClass_SecondObject,
 }
 
 /**
  * The isomorphic [PrivateInterfaceSealedClassEnum] for [this].
  */
-val PrivateInterfaceSealedClass.enum: PrivateInterfaceSealedClassEnum
+public val PrivateInterfaceSealedClass.`enum`: PrivateInterfaceSealedClassEnum
     get() = PrivateInterfaceSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [PrivateInterfaceSealedClass] for [this].
  */
-val PrivateInterfaceSealedClassEnum.sealedObject: PrivateInterfaceSealedClass
+public val PrivateInterfaceSealedClassEnum.sealedObject: PrivateInterfaceSealedClass
     get() = PrivateInterfaceSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [PrivateInterfaceSealedClass]
  */
-object PrivateInterfaceSealedClassSealedEnum : SealedEnum<PrivateInterfaceSealedClass>,
+public object PrivateInterfaceSealedClassSealedEnum : SealedEnum<PrivateInterfaceSealedClass>,
         SealedEnumWithEnumProvider<PrivateInterfaceSealedClass, PrivateInterfaceSealedClassEnum>,
         EnumForSealedEnumProvider<PrivateInterfaceSealedClass, PrivateInterfaceSealedClassEnum> {
-    override val values: List<PrivateInterfaceSealedClass> = listOf(
+    public override val values: List<PrivateInterfaceSealedClass> = listOf(
         PrivateInterfaceSealedClass.FirstObject,
         PrivateInterfaceSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<PrivateInterfaceSealedClassEnum>
+    public override val enumClass: Class<PrivateInterfaceSealedClassEnum>
         get() = PrivateInterfaceSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: PrivateInterfaceSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: PrivateInterfaceSealedClass): Int = when (obj) {
         PrivateInterfaceSealedClass.FirstObject -> 0
         PrivateInterfaceSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: PrivateInterfaceSealedClass): String = when (obj) {
+    public override fun nameOf(obj: PrivateInterfaceSealedClass): String = when (obj) {
         PrivateInterfaceSealedClass.FirstObject -> "PrivateInterfaceSealedClass_FirstObject"
         PrivateInterfaceSealedClass.SecondObject -> "PrivateInterfaceSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): PrivateInterfaceSealedClass = when (name) {
+    public override fun valueOf(name: String): PrivateInterfaceSealedClass = when (name) {
         "PrivateInterfaceSealedClass_FirstObject" -> PrivateInterfaceSealedClass.FirstObject
         "PrivateInterfaceSealedClass_SecondObject" -> PrivateInterfaceSealedClass.SecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: PrivateInterfaceSealedClass):
+    public override fun sealedObjectToEnum(obj: PrivateInterfaceSealedClass):
             PrivateInterfaceSealedClassEnum = when (obj) {
         PrivateInterfaceSealedClass.FirstObject ->
                 PrivateInterfaceSealedClassEnum.PrivateInterfaceSealedClass_FirstObject
@@ -88,7 +87,7 @@ object PrivateInterfaceSealedClassSealedEnum : SealedEnum<PrivateInterfaceSealed
                 PrivateInterfaceSealedClassEnum.PrivateInterfaceSealedClass_SecondObject
     }
 
-    override fun enumToSealedObject(enum: PrivateInterfaceSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: PrivateInterfaceSealedClassEnum):
             PrivateInterfaceSealedClass = when (enum) {
         PrivateInterfaceSealedClassEnum.PrivateInterfaceSealedClass_FirstObject ->
                 PrivateInterfaceSealedClass.FirstObject
@@ -100,25 +99,25 @@ object PrivateInterfaceSealedClassSealedEnum : SealedEnum<PrivateInterfaceSealed
 /**
  * The index of [this] in the values list.
  */
-val PrivateInterfaceSealedClass.ordinal: Int
+public val PrivateInterfaceSealedClass.ordinal: Int
     get() = PrivateInterfaceSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val PrivateInterfaceSealedClass.name: String
+public val PrivateInterfaceSealedClass.name: String
     get() = PrivateInterfaceSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [PrivateInterfaceSealedClass] objects.
  */
-val PrivateInterfaceSealedClass.Companion.values: List<PrivateInterfaceSealedClass>
+public val PrivateInterfaceSealedClass.Companion.values: List<PrivateInterfaceSealedClass>
     get() = PrivateInterfaceSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [PrivateInterfaceSealedClass]
  */
-val PrivateInterfaceSealedClass.Companion.sealedEnum: PrivateInterfaceSealedClassSealedEnum
+public val PrivateInterfaceSealedClass.Companion.sealedEnum: PrivateInterfaceSealedClassSealedEnum
     get() = PrivateInterfaceSealedClassSealedEnum
 
 /**
@@ -127,8 +126,8 @@ val PrivateInterfaceSealedClass.Companion.sealedEnum: PrivateInterfaceSealedClas
  * If the given name doesn't correspond to any [PrivateInterfaceSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun PrivateInterfaceSealedClass.Companion.valueOf(name: String): PrivateInterfaceSealedClass =
-        PrivateInterfaceSealedClassSealedEnum.valueOf(name)
+public fun PrivateInterfaceSealedClass.Companion.valueOf(name: String): PrivateInterfaceSealedClass
+        = PrivateInterfaceSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()
 
@@ -164,18 +163,17 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class
  * [ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass]
  */
-enum class ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum(
+public enum class ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum(
     sealedObject: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass
 ) : JavaProtectedInterfaceBaseClass.ProtectedInterface by sealedObject {
     ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_FirstObject(com.livefront.sealedenum.compilation.visibility.ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject),
-
-    ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_SecondObject(com.livefront.sealedenum.compilation.visibility.ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject)
+    ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_SecondObject(com.livefront.sealedenum.compilation.visibility.ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject),
 }
 
 /**
  * The isomorphic [ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum] for [this].
  */
-val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.enum:
+public val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.`enum`:
         ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum
     get() =
             ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum.sealedObjectToEnum(this)
@@ -183,7 +181,7 @@ val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.enum:
 /**
  * The isomorphic [ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass] for [this].
  */
-val ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum.sealedObject:
+public val ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum.sealedObject:
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass
     get() =
             ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum.enumToSealedObject(this)
@@ -192,37 +190,39 @@ val ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum.sealedObject:
  * An implementation of [SealedEnum] for the sealed class
  * [ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass]
  */
-object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum :
+public object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum :
         SealedEnum<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass>,
         SealedEnumWithEnumProvider<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass,
         ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>,
         EnumForSealedEnumProvider<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass,
         ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum> {
-    override val values: List<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass> = listOf(
+    public override val values: List<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass> =
+            listOf(
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject,
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>
+    public override val enumClass:
+            Class<ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>
         get() = ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass): Int =
-            when (obj) {
+    public override fun ordinalOf(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass):
+            Int = when (obj) {
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject -> 0
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass): String =
-            when (obj) {
+    public override fun nameOf(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass):
+            String = when (obj) {
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject ->
                 "ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_FirstObject"
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject ->
                 "ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass =
-            when (name) {
+    public override fun valueOf(name: String):
+            ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass = when (name) {
         "ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_FirstObject" ->
                 ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject
         "ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_SecondObject" ->
@@ -230,7 +230,7 @@ object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum :
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override
+    public override
             fun sealedObjectToEnum(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass):
             ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum = when (obj) {
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject ->
@@ -239,8 +239,8 @@ object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum :
                 ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum.ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_SecondObject
     }
 
-    override
-            fun enumToSealedObject(enum: ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum):
+    public override
+            fun enumToSealedObject(`enum`: ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum):
             ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass = when (enum) {
         ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum.ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_FirstObject ->
                 ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject
@@ -252,19 +252,19 @@ object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum :
 /**
  * The index of [this] in the values list.
  */
-val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.ordinal: Int
+public val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.ordinal: Int
     get() = ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.name: String
+public val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.name: String
     get() = ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass] objects.
  */
-val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.Companion.values:
+public val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.Companion.values:
         List<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass>
     get() = ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum.values
 
@@ -272,7 +272,7 @@ val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.Companion.values:
  * Returns an implementation of [SealedEnum] for the sealed class
  * [ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass]
  */
-val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.Companion.sealedEnum:
+public val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.Companion.sealedEnum:
         ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum
     get() = ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum
 
@@ -284,7 +284,8 @@ val ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.Companion.sealedE
  * [ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass], an [IllegalArgumentException] will be
  * thrown.
  */
-fun ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.Companion.valueOf(name: String):
+public
+        fun ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.Companion.valueOf(name: String):
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass =
         ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum.valueOf(name)
 
@@ -323,12 +324,11 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class
  * [ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass]
  */
-enum class
+public enum class
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum
         {
     ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_FirstObject,
-
-    ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_SecondObject
+    ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_SecondObject,
 }
 
 /**
@@ -336,7 +336,8 @@ enum class
  * [ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum] for
  * [this].
  */
-val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.enum:
+public
+        val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.`enum`:
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum
     get() =
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum.sealedObjectToEnum(this)
@@ -346,7 +347,8 @@ val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterface
  * [ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass] for
  * [this].
  */
-val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum.sealedObject:
+public
+        val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum.sealedObject:
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass
     get() =
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum.enumToSealedObject(this)
@@ -355,7 +357,7 @@ val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterface
  * An implementation of [SealedEnum] for the sealed class
  * [ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass]
  */
-object
+public object
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum
         :
         SealedEnum<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass>,
@@ -364,7 +366,7 @@ object
         EnumForSealedEnumProvider<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass,
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum>
         {
-    override val values:
+    public override val values:
             List<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass>
             = listOf(
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject,
@@ -372,12 +374,12 @@ object
     )
 
 
-    override val enumClass:
+    public override val enumClass:
             Class<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum>
         get() =
                 ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum::class.java
 
-    override
+    public override
             fun ordinalOf(obj: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass):
             Int = when (obj) {
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject ->
@@ -386,7 +388,7 @@ object
                 1
     }
 
-    override
+    public override
             fun nameOf(obj: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass):
             String = when (obj) {
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject ->
@@ -395,7 +397,7 @@ object
                 "ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String):
+    public override fun valueOf(name: String):
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass
             = when (name) {
         "ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_FirstObject" ->
@@ -405,7 +407,7 @@ object
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override
+    public override
             fun sealedObjectToEnum(obj: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass):
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum
             = when (obj) {
@@ -415,8 +417,8 @@ object
                 ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum.ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_SecondObject
     }
 
-    override
-            fun enumToSealedObject(enum: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum):
+    public override
+            fun enumToSealedObject(`enum`: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum):
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass
             = when (enum) {
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum.ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_FirstObject ->
@@ -429,7 +431,8 @@ object
 /**
  * The index of [this] in the values list.
  */
-val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.ordinal:
+public
+        val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.ordinal:
         Int
     get() =
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum.ordinalOf(this)
@@ -437,7 +440,8 @@ val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterface
 /**
  * The name of [this] for use with valueOf.
  */
-val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.name:
+public
+        val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.name:
         String
     get() =
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum.nameOf(this)
@@ -446,7 +450,8 @@ val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterface
  * A list of all
  * [ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass] objects.
  */
-val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.Companion.values:
+public
+        val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.Companion.values:
         List<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass>
     get() =
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum.values
@@ -455,7 +460,8 @@ val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterface
  * Returns an implementation of [SealedEnum] for the sealed class
  * [ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass]
  */
-val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.Companion.sealedEnum:
+public
+        val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.Companion.sealedEnum:
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum
     get() =
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum
@@ -469,7 +475,8 @@ val ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterface
  * [ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.Companion.valueOf(name: String):
+public
+        fun ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.Companion.valueOf(name: String):
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass =
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum.valueOf(name)
 

--- a/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
+++ b/sealedenumprocessor/src/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
@@ -31,56 +31,54 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [InternalObjectsSealedClass]
  */
-enum class InternalObjectsSealedClassEnum {
+public enum class InternalObjectsSealedClassEnum {
     InternalObjectsSealedClass_FirstObject,
-
     InternalObjectsSealedClass_SecondObject,
-
-    InternalObjectsSealedClass_InnerSealedClass_ThirdObject
+    InternalObjectsSealedClass_InnerSealedClass_ThirdObject,
 }
 
 /**
  * The isomorphic [InternalObjectsSealedClassEnum] for [this].
  */
-val InternalObjectsSealedClass.enum: InternalObjectsSealedClassEnum
+public val InternalObjectsSealedClass.`enum`: InternalObjectsSealedClassEnum
     get() = InternalObjectsSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [InternalObjectsSealedClass] for [this].
  */
-val InternalObjectsSealedClassEnum.sealedObject: InternalObjectsSealedClass
+public val InternalObjectsSealedClassEnum.sealedObject: InternalObjectsSealedClass
     get() = InternalObjectsSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [InternalObjectsSealedClass]
  */
-object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsSealedClass>,
+public object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsSealedClass>,
         SealedEnumWithEnumProvider<InternalObjectsSealedClass, InternalObjectsSealedClassEnum>,
         EnumForSealedEnumProvider<InternalObjectsSealedClass, InternalObjectsSealedClassEnum> {
-    override val values: List<InternalObjectsSealedClass> = listOf(
+    public override val values: List<InternalObjectsSealedClass> = listOf(
         InternalObjectsSealedClass.FirstObject,
         InternalObjectsSealedClass.SecondObject,
         InternalObjectsSealedClass.InnerSealedClass.ThirdObject
     )
 
 
-    override val enumClass: Class<InternalObjectsSealedClassEnum>
+    public override val enumClass: Class<InternalObjectsSealedClassEnum>
         get() = InternalObjectsSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: InternalObjectsSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: InternalObjectsSealedClass): Int = when (obj) {
         InternalObjectsSealedClass.FirstObject -> 0
         InternalObjectsSealedClass.SecondObject -> 1
         InternalObjectsSealedClass.InnerSealedClass.ThirdObject -> 2
     }
 
-    override fun nameOf(obj: InternalObjectsSealedClass): String = when (obj) {
+    public override fun nameOf(obj: InternalObjectsSealedClass): String = when (obj) {
         InternalObjectsSealedClass.FirstObject -> "InternalObjectsSealedClass_FirstObject"
         InternalObjectsSealedClass.SecondObject -> "InternalObjectsSealedClass_SecondObject"
         InternalObjectsSealedClass.InnerSealedClass.ThirdObject ->
                 "InternalObjectsSealedClass_InnerSealedClass_ThirdObject"
     }
 
-    override fun valueOf(name: String): InternalObjectsSealedClass = when (name) {
+    public override fun valueOf(name: String): InternalObjectsSealedClass = when (name) {
         "InternalObjectsSealedClass_FirstObject" -> InternalObjectsSealedClass.FirstObject
         "InternalObjectsSealedClass_SecondObject" -> InternalObjectsSealedClass.SecondObject
         "InternalObjectsSealedClass_InnerSealedClass_ThirdObject" ->
@@ -88,8 +86,8 @@ object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsSealedCl
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: InternalObjectsSealedClass): InternalObjectsSealedClassEnum
-            = when (obj) {
+    public override fun sealedObjectToEnum(obj: InternalObjectsSealedClass):
+            InternalObjectsSealedClassEnum = when (obj) {
         InternalObjectsSealedClass.FirstObject ->
                 InternalObjectsSealedClassEnum.InternalObjectsSealedClass_FirstObject
         InternalObjectsSealedClass.SecondObject ->
@@ -98,7 +96,7 @@ object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsSealedCl
                 InternalObjectsSealedClassEnum.InternalObjectsSealedClass_InnerSealedClass_ThirdObject
     }
 
-    override fun enumToSealedObject(enum: InternalObjectsSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: InternalObjectsSealedClassEnum):
             InternalObjectsSealedClass = when (enum) {
         InternalObjectsSealedClassEnum.InternalObjectsSealedClass_FirstObject ->
                 InternalObjectsSealedClass.FirstObject
@@ -112,25 +110,25 @@ object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsSealedCl
 /**
  * The index of [this] in the values list.
  */
-val InternalObjectsSealedClass.ordinal: Int
+public val InternalObjectsSealedClass.ordinal: Int
     get() = InternalObjectsSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val InternalObjectsSealedClass.name: String
+public val InternalObjectsSealedClass.name: String
     get() = InternalObjectsSealedClassSealedEnum.nameOf(this)
 
 /**
  * A list of all [InternalObjectsSealedClass] objects.
  */
-val InternalObjectsSealedClass.Companion.values: List<InternalObjectsSealedClass>
+public val InternalObjectsSealedClass.Companion.values: List<InternalObjectsSealedClass>
     get() = InternalObjectsSealedClassSealedEnum.values
 
 /**
  * Returns an implementation of [SealedEnum] for the sealed class [InternalObjectsSealedClass]
  */
-val InternalObjectsSealedClass.Companion.sealedEnum: InternalObjectsSealedClassSealedEnum
+public val InternalObjectsSealedClass.Companion.sealedEnum: InternalObjectsSealedClassSealedEnum
     get() = InternalObjectsSealedClassSealedEnum
 
 /**
@@ -139,7 +137,7 @@ val InternalObjectsSealedClass.Companion.sealedEnum: InternalObjectsSealedClassS
  * If the given name doesn't correspond to any [InternalObjectsSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-fun InternalObjectsSealedClass.Companion.valueOf(name: String): InternalObjectsSealedClass =
+public fun InternalObjectsSealedClass.Companion.valueOf(name: String): InternalObjectsSealedClass =
         InternalObjectsSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()
@@ -170,14 +168,13 @@ import kotlin.collections.List
  */
 internal enum class InternalSealedClassEnum {
     InternalSealedClass_FirstObject,
-
-    InternalSealedClass_SecondObject
+    InternalSealedClass_SecondObject,
 }
 
 /**
  * The isomorphic [InternalSealedClassEnum] for [this].
  */
-internal val InternalSealedClass.enum: InternalSealedClassEnum
+internal val InternalSealedClass.`enum`: InternalSealedClassEnum
     get() = InternalSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
@@ -192,39 +189,39 @@ internal val InternalSealedClassEnum.sealedObject: InternalSealedClass
 internal object InternalSealedClassSealedEnum : SealedEnum<InternalSealedClass>,
         SealedEnumWithEnumProvider<InternalSealedClass, InternalSealedClassEnum>,
         EnumForSealedEnumProvider<InternalSealedClass, InternalSealedClassEnum> {
-    override val values: List<InternalSealedClass> = listOf(
+    public override val values: List<InternalSealedClass> = listOf(
         InternalSealedClass.FirstObject,
         InternalSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<InternalSealedClassEnum>
+    public override val enumClass: Class<InternalSealedClassEnum>
         get() = InternalSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: InternalSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: InternalSealedClass): Int = when (obj) {
         InternalSealedClass.FirstObject -> 0
         InternalSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: InternalSealedClass): String = when (obj) {
+    public override fun nameOf(obj: InternalSealedClass): String = when (obj) {
         InternalSealedClass.FirstObject -> "InternalSealedClass_FirstObject"
         InternalSealedClass.SecondObject -> "InternalSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): InternalSealedClass = when (name) {
+    public override fun valueOf(name: String): InternalSealedClass = when (name) {
         "InternalSealedClass_FirstObject" -> InternalSealedClass.FirstObject
         "InternalSealedClass_SecondObject" -> InternalSealedClass.SecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: InternalSealedClass): InternalSealedClassEnum = when
+    public override fun sealedObjectToEnum(obj: InternalSealedClass): InternalSealedClassEnum = when
             (obj) {
         InternalSealedClass.FirstObject -> InternalSealedClassEnum.InternalSealedClass_FirstObject
         InternalSealedClass.SecondObject -> InternalSealedClassEnum.InternalSealedClass_SecondObject
     }
 
-    override fun enumToSealedObject(enum: InternalSealedClassEnum): InternalSealedClass = when
-            (enum) {
+    public override fun enumToSealedObject(`enum`: InternalSealedClassEnum): InternalSealedClass =
+            when (enum) {
         InternalSealedClassEnum.InternalSealedClass_FirstObject -> InternalSealedClass.FirstObject
         InternalSealedClassEnum.InternalSealedClass_SecondObject -> InternalSealedClass.SecondObject
     }
@@ -289,56 +286,55 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [InternalCompanionSealedClass]
  */
-enum class InternalCompanionSealedClassEnum {
+public enum class InternalCompanionSealedClassEnum {
     InternalCompanionSealedClass_FirstObject,
-
-    InternalCompanionSealedClass_SecondObject
+    InternalCompanionSealedClass_SecondObject,
 }
 
 /**
  * The isomorphic [InternalCompanionSealedClassEnum] for [this].
  */
-val InternalCompanionSealedClass.enum: InternalCompanionSealedClassEnum
+public val InternalCompanionSealedClass.`enum`: InternalCompanionSealedClassEnum
     get() = InternalCompanionSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
  * The isomorphic [InternalCompanionSealedClass] for [this].
  */
-val InternalCompanionSealedClassEnum.sealedObject: InternalCompanionSealedClass
+public val InternalCompanionSealedClassEnum.sealedObject: InternalCompanionSealedClass
     get() = InternalCompanionSealedClassSealedEnum.enumToSealedObject(this)
 
 /**
  * An implementation of [SealedEnum] for the sealed class [InternalCompanionSealedClass]
  */
-object InternalCompanionSealedClassSealedEnum : SealedEnum<InternalCompanionSealedClass>,
+public object InternalCompanionSealedClassSealedEnum : SealedEnum<InternalCompanionSealedClass>,
         SealedEnumWithEnumProvider<InternalCompanionSealedClass, InternalCompanionSealedClassEnum>,
         EnumForSealedEnumProvider<InternalCompanionSealedClass, InternalCompanionSealedClassEnum> {
-    override val values: List<InternalCompanionSealedClass> = listOf(
+    public override val values: List<InternalCompanionSealedClass> = listOf(
         InternalCompanionSealedClass.FirstObject,
         InternalCompanionSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<InternalCompanionSealedClassEnum>
+    public override val enumClass: Class<InternalCompanionSealedClassEnum>
         get() = InternalCompanionSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: InternalCompanionSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: InternalCompanionSealedClass): Int = when (obj) {
         InternalCompanionSealedClass.FirstObject -> 0
         InternalCompanionSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: InternalCompanionSealedClass): String = when (obj) {
+    public override fun nameOf(obj: InternalCompanionSealedClass): String = when (obj) {
         InternalCompanionSealedClass.FirstObject -> "InternalCompanionSealedClass_FirstObject"
         InternalCompanionSealedClass.SecondObject -> "InternalCompanionSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): InternalCompanionSealedClass = when (name) {
+    public override fun valueOf(name: String): InternalCompanionSealedClass = when (name) {
         "InternalCompanionSealedClass_FirstObject" -> InternalCompanionSealedClass.FirstObject
         "InternalCompanionSealedClass_SecondObject" -> InternalCompanionSealedClass.SecondObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: InternalCompanionSealedClass):
+    public override fun sealedObjectToEnum(obj: InternalCompanionSealedClass):
             InternalCompanionSealedClassEnum = when (obj) {
         InternalCompanionSealedClass.FirstObject ->
                 InternalCompanionSealedClassEnum.InternalCompanionSealedClass_FirstObject
@@ -346,7 +342,7 @@ object InternalCompanionSealedClassSealedEnum : SealedEnum<InternalCompanionSeal
                 InternalCompanionSealedClassEnum.InternalCompanionSealedClass_SecondObject
     }
 
-    override fun enumToSealedObject(enum: InternalCompanionSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: InternalCompanionSealedClassEnum):
             InternalCompanionSealedClass = when (enum) {
         InternalCompanionSealedClassEnum.InternalCompanionSealedClass_FirstObject ->
                 InternalCompanionSealedClass.FirstObject
@@ -358,13 +354,13 @@ object InternalCompanionSealedClassSealedEnum : SealedEnum<InternalCompanionSeal
 /**
  * The index of [this] in the values list.
  */
-val InternalCompanionSealedClass.ordinal: Int
+public val InternalCompanionSealedClass.ordinal: Int
     get() = InternalCompanionSealedClassSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-val InternalCompanionSealedClass.name: String
+public val InternalCompanionSealedClass.name: String
     get() = InternalCompanionSealedClassSealedEnum.nameOf(this)
 
 /**
@@ -417,14 +413,13 @@ import kotlin.collections.List
  */
 internal enum class InternalSealedAndCompanionSealedClassEnum {
     InternalSealedAndCompanionSealedClass_FirstObject,
-
-    InternalSealedAndCompanionSealedClass_SecondObject
+    InternalSealedAndCompanionSealedClass_SecondObject,
 }
 
 /**
  * The isomorphic [InternalSealedAndCompanionSealedClassEnum] for [this].
  */
-internal val InternalSealedAndCompanionSealedClass.enum: InternalSealedAndCompanionSealedClassEnum
+internal val InternalSealedAndCompanionSealedClass.`enum`: InternalSealedAndCompanionSealedClassEnum
     get() = InternalSealedAndCompanionSealedClassSealedEnum.sealedObjectToEnum(this)
 
 /**
@@ -443,28 +438,28 @@ internal object InternalSealedAndCompanionSealedClassSealedEnum :
         InternalSealedAndCompanionSealedClassEnum>,
         EnumForSealedEnumProvider<InternalSealedAndCompanionSealedClass,
         InternalSealedAndCompanionSealedClassEnum> {
-    override val values: List<InternalSealedAndCompanionSealedClass> = listOf(
+    public override val values: List<InternalSealedAndCompanionSealedClass> = listOf(
         InternalSealedAndCompanionSealedClass.FirstObject,
         InternalSealedAndCompanionSealedClass.SecondObject
     )
 
 
-    override val enumClass: Class<InternalSealedAndCompanionSealedClassEnum>
+    public override val enumClass: Class<InternalSealedAndCompanionSealedClassEnum>
         get() = InternalSealedAndCompanionSealedClassEnum::class.java
 
-    override fun ordinalOf(obj: InternalSealedAndCompanionSealedClass): Int = when (obj) {
+    public override fun ordinalOf(obj: InternalSealedAndCompanionSealedClass): Int = when (obj) {
         InternalSealedAndCompanionSealedClass.FirstObject -> 0
         InternalSealedAndCompanionSealedClass.SecondObject -> 1
     }
 
-    override fun nameOf(obj: InternalSealedAndCompanionSealedClass): String = when (obj) {
+    public override fun nameOf(obj: InternalSealedAndCompanionSealedClass): String = when (obj) {
         InternalSealedAndCompanionSealedClass.FirstObject ->
                 "InternalSealedAndCompanionSealedClass_FirstObject"
         InternalSealedAndCompanionSealedClass.SecondObject ->
                 "InternalSealedAndCompanionSealedClass_SecondObject"
     }
 
-    override fun valueOf(name: String): InternalSealedAndCompanionSealedClass = when (name) {
+    public override fun valueOf(name: String): InternalSealedAndCompanionSealedClass = when (name) {
         "InternalSealedAndCompanionSealedClass_FirstObject" ->
                 InternalSealedAndCompanionSealedClass.FirstObject
         "InternalSealedAndCompanionSealedClass_SecondObject" ->
@@ -472,7 +467,7 @@ internal object InternalSealedAndCompanionSealedClassSealedEnum :
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
-    override fun sealedObjectToEnum(obj: InternalSealedAndCompanionSealedClass):
+    public override fun sealedObjectToEnum(obj: InternalSealedAndCompanionSealedClass):
             InternalSealedAndCompanionSealedClassEnum = when (obj) {
         InternalSealedAndCompanionSealedClass.FirstObject ->
                 InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_FirstObject
@@ -480,7 +475,7 @@ internal object InternalSealedAndCompanionSealedClassSealedEnum :
                 InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_SecondObject
     }
 
-    override fun enumToSealedObject(enum: InternalSealedAndCompanionSealedClassEnum):
+    public override fun enumToSealedObject(`enum`: InternalSealedAndCompanionSealedClassEnum):
             InternalSealedAndCompanionSealedClass = when (enum) {
         InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_FirstObject ->
                 InternalSealedAndCompanionSealedClass.FirstObject


### PR DESCRIPTION
Updates Kotlin-Poet to 1.7.2 with no functional changes. This update removes some compilation warnings due to mixing of artifacts for Kotlin 1.3 and 1.4, allows some generated code to use trailing commas, and also generates explicit-api-mode compatible code by default.