### PR TITLE
Enable explicit API mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,10 @@ subprojects {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlin {
+        explicitApi()
+    }
+
     tasks {
         compileKotlin {
             kotlinOptions {

--- a/sealedenum/src/main/kotlin/com/livefront/sealedenum/EnumForSealedEnumProvider.kt
+++ b/sealedenum/src/main/kotlin/com/livefront/sealedenum/EnumForSealedEnumProvider.kt
@@ -3,21 +3,21 @@ package com.livefront.sealedenum
 /**
  * Defines a provider for interoperability between a [SealedEnum] for type [T] and a normal enum class [E].
  */
-interface EnumForSealedEnumProvider<T, E : Enum<E>> {
+public interface EnumForSealedEnumProvider<T, E : Enum<E>> {
     /**
      * A mapping of the sealed object of type [T] to the enum constant of type [E]. Together with the inverse function
      * [enumToSealedObject], this is an isomorphism.
      */
-    fun sealedObjectToEnum(obj: T): E
+    public fun sealedObjectToEnum(obj: T): E
 
     /**
      * A mapping of the enum constant of type [E] to the enum constant of type [T]. Together with the inverse function
      * [sealedObjectToEnum], this is an isomorphism.
      */
-    fun enumToSealedObject(enum: E): T
+    public fun enumToSealedObject(enum: E): T
 
     /**
      * The class object for the enum.
      */
-    val enumClass: Class<E>
+    public val enumClass: Class<E>
 }

--- a/sealedenum/src/main/kotlin/com/livefront/sealedenum/GenSealedEnum.kt
+++ b/sealedenum/src/main/kotlin/com/livefront/sealedenum/GenSealedEnum.kt
@@ -199,7 +199,7 @@ package com.livefront.sealedenum
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
 @Repeatable
-annotation class GenSealedEnum(
+public annotation class GenSealedEnum(
     val traversalOrder: TreeTraversalOrder = TreeTraversalOrder.IN_ORDER,
     val generateEnum: Boolean = false
 )
@@ -207,4 +207,4 @@ annotation class GenSealedEnum(
 /**
  * This is the container annotation for multiple [GenSealedEnum] annotations.
  */
-annotation class GenSealedEnums(vararg val value: GenSealedEnum)
+public annotation class GenSealedEnums(vararg val value: GenSealedEnum)

--- a/sealedenum/src/main/kotlin/com/livefront/sealedenum/SealedEnum.kt
+++ b/sealedenum/src/main/kotlin/com/livefront/sealedenum/SealedEnum.kt
@@ -8,43 +8,43 @@ package com.livefront.sealedenum
  * object with [GenSealedEnum]. Additionally, an implementation of [SealedEnum] can be created for a normal `Enum` with
  * [createSealedEnumFromEnum].
  */
-interface SealedEnum<T> : Comparator<T> {
+public interface SealedEnum<T> : Comparator<T> {
 
     /**
      * A list of all [T] objects.
      */
-    val values: List<T>
+    public val values: List<T>
 
     /**
      * Returns the index of [obj] in the [values] list.
      */
-    fun ordinalOf(obj: T): Int
+    public fun ordinalOf(obj: T): Int
 
     /**
      * Returns the name of [obj] for use with [valueOf].
      */
-    fun nameOf(obj: T): String
+    public fun nameOf(obj: T): String
 
     /**
      * Returns the [T] object for the given [name].
      *
      * If the given name doesn't correspond to any [T], an [IllegalArgumentException] will be thrown.
      */
-    fun valueOf(name: String): T
+    public fun valueOf(name: String): T
 
-    override fun compare(first: T, second: T) = ordinalOf(first) - ordinalOf(second)
+    public override fun compare(first: T, second: T): Int = ordinalOf(first) - ordinalOf(second)
 }
 
 /**
  * Creates a [SealedEnumWithEnumProvider] for the enum [E].
  */
-inline fun <reified E : Enum<E>> createSealedEnumFromEnum(): SealedEnumWithEnumProvider<E, E> =
+public inline fun <reified E : Enum<E>> createSealedEnumFromEnum(): SealedEnumWithEnumProvider<E, E> =
     createSealedEnumFromEnumArray(enumValues(), E::class.java)
 
 /**
  * Creates a [SealedEnumWithEnumProvider] for the enum [E] with the given array of enum values.
  */
-fun <E : Enum<E>> createSealedEnumFromEnumArray(
+public fun <E : Enum<E>> createSealedEnumFromEnumArray(
     values: Array<E>,
     enumClass: Class<E>
 ): SealedEnumWithEnumProvider<E, E> = object : SealedEnumWithEnumProvider<E, E> {

--- a/sealedenum/src/main/kotlin/com/livefront/sealedenum/SealedEnumWithEnumProvider.kt
+++ b/sealedenum/src/main/kotlin/com/livefront/sealedenum/SealedEnumWithEnumProvider.kt
@@ -3,4 +3,4 @@ package com.livefront.sealedenum
 /**
  * A [SealedEnum] along with a [EnumForSealedEnumProvider].
  */
-interface SealedEnumWithEnumProvider<T, E : Enum<E>> : SealedEnum<T>, EnumForSealedEnumProvider<T, E>
+public interface SealedEnumWithEnumProvider<T, E : Enum<E>> : SealedEnum<T>, EnumForSealedEnumProvider<T, E>

--- a/sealedenum/src/main/kotlin/com/livefront/sealedenum/TreeTraversalOrder.kt
+++ b/sealedenum/src/main/kotlin/com/livefront/sealedenum/TreeTraversalOrder.kt
@@ -3,7 +3,7 @@ package com.livefront.sealedenum
 /**
  * An enum specifying the traversal order for the list of sealed objects.
  */
-enum class TreeTraversalOrder {
+public enum class TreeTraversalOrder {
     /**
      * All objects that are direct children of a sealed class will be listed before objects in subclasses that are
      * themselves sealed.

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/WildcardedTypeParameters.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/WildcardedTypeParameters.kt
@@ -14,7 +14,7 @@ import com.squareup.kotlinpoet.TypeSpec
  * In particular, single invariant types can be replaced with the type directly. In all other cases (multiple bounds,
  * other types of variance) the only thing we can do is wildcard the type.
  */
-val TypeSpec.wildcardedTypeVariables: List<TypeName>
+internal val TypeSpec.wildcardedTypeVariables: List<TypeName>
     get() = typeVariables
         .map {
             if (it.bounds.size == 1) {

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/CamelCase.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/CamelCase.kt
@@ -5,5 +5,5 @@ package com.livefront.sealedenum.internal.spec
  *
  * This function assumes that [pascalCase] is non-empty.
  */
-fun pascalCaseToCamelCase(pascalCase: String): String =
+internal fun pascalCaseToCamelCase(pascalCase: String): String =
     pascalCase.take(1).toLowerCase() + pascalCase.drop(1)

--- a/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedClassExtensions.kt
+++ b/sealedenumprocessor/src/main/kotlin/com/livefront/sealedenum/internal/spec/SealedClassExtensions.kt
@@ -3,9 +3,9 @@ package com.livefront.sealedenum.internal.spec
 import com.livefront.sealedenum.SealedEnum
 import com.squareup.kotlinpoet.ClassName
 
-typealias SealedClass = ClassName
+internal typealias SealedClass = ClassName
 
-typealias SealedObject = ClassName
+internal typealias SealedObject = ClassName
 
 /**
  * Creates the name of the [SealedEnum] for the given [SealedClass] and [enumPrefix].


### PR DESCRIPTION
Enables explicitApiMode, which means that public methods, properties must be explicitly marked as such and have explicit return types.