### PR TITLE
Enable warnings as errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,12 +40,14 @@ subprojects {
         compileKotlin {
             kotlinOptions {
                 jvmTarget = JavaVersion.VERSION_1_8.toString()
+                allWarningsAsErrors = true
             }
         }
 
         compileTestKotlin {
             kotlinOptions {
                 jvmTarget = JavaVersion.VERSION_1_8.toString()
+                allWarningsAsErrors = true
             }
         }
 


### PR DESCRIPTION
Enables `allWarningsAsErrors` for Kotlin compiler warnings.