### PR TITLE
Remove Danger specific environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,5 @@ jobs:
         # Run Danger for PRs originating from within the repo (for fork PRs the token won't give permission to comment)
         if: github.event_name == 'pull_request' && matrix.java-version == '1.8' && github.event.pull_request.head.repo.full_name == github.repository
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bundle exec danger


### PR DESCRIPTION
A small PR to remove setting a Danger-specific environment variable for the GitHub authentication token.