### PR TITLE
Remove jcenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,8 @@ plugins {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven(url = "https://dl.bintray.com/kotlin/kotlinx/")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     const val autoService = "1.0-rc7"
-    const val detekt = "1.12.0"
+    const val detekt = "1.15.0"
     const val dokka = "1.4.0"
     const val incap = "0.3"
     const val junit = "5.6.2"


### PR DESCRIPTION
This PR removes `jcenter` as a package repository, replacing it with `mavenCenteral`

The only difficulty here was https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-html-jvm, which is used by `detekt`. To get access to it without `jcenter`, I updated `detekt` and added the `kotlinx` repo here: https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-html-jvm