### PR TITLE
Revert to using jcenter for dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 allprojects {
     repositories {
         mavenCentral()
-        maven(url = "https://dl.bintray.com/kotlin/kotlinx/")
+        jcenter()
     }
 }
 


### PR DESCRIPTION
This PR reverts to using `jcenter` for now for Dokka to work correctly.