### PR TITLE
Update Gradle to 6.8.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip


### PR DESCRIPTION
A version bump to the Gradle wrapper version. The latest versions of Gradle improve the behavior of `build.gradle.kts` scripts greatly, which this project uses everywhere.