### PR TITLE
Switch to ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,23 +36,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ matrix.java-version }}-
 
-      - name: Cache gems
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
       - name: Configure Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.2'
-
-      - name: bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install --without=documentation --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Configure JDK
         uses: actions/setup-java@v1


### PR DESCRIPTION
This PR updates CI to use https://github.com/actions/setup-ruby instead of https://github.com/ruby/setup-ruby, since the latter was deprecated.

As a bonus, the new version supports caching inherently, making the workflow simpler!