### PR TITLE
Prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.3.0
+## Breaking changes:
+- Artifact ids were updated (`sealedenum` -> `runtime` and `sealedenumprocessor` -> `processor`).
+  This was done to accomodate alternate generation implementations, such as by [KSP](https://github.com/google/ksp)
+
+## Miscellaneous updates:
+- Switch to GitHub actions for CI
+- Various dependency updates
+
 # 0.2.0
 ## Features:
 - Added extension properties and methods to make `sealed-enum` easier to use in common cases.

--- a/README.md
+++ b/README.md
@@ -348,8 +348,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.livefront.sealed-enum:runtime:0.2.0")
-    kapt("com.github.livefront.sealed-enum:processor:0.2.0")
+    implementation("com.github.livefront.sealed-enum:runtime:0.3.0")
+    kapt("com.github.livefront.sealed-enum:processor:0.3.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,6 @@ subprojects {
         plugin<org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper>()
         plugin<JacocoPlugin>()
         plugin<io.gitlab.arturbosch.detekt.DetektPlugin>()
-        plugin<MavenPublishPlugin>()
         plugin<org.jetbrains.dokka.gradle.DokkaPlugin>()
     }
 
@@ -73,49 +72,51 @@ subprojects {
             outputDirectory.set(javadoc.get().destinationDir)
         }
 
-        val sourcesJar by creating(Jar::class) {
-            archiveClassifier.set("sources")
-            from(sourceSets.main.get().allSource)
-        }
+        plugins.withType(MavenPublishPlugin::class) {
+            val sourcesJar by creating(Jar::class) {
+                archiveClassifier.set("sources")
+                from(sourceSets.main.get().allSource)
+            }
 
-        val javadocJar by creating(Jar::class) {
-            archiveClassifier.set("javadoc")
-            from(dokkaHtml)
-        }
+            val javadocJar by creating(Jar::class) {
+                archiveClassifier.set("javadoc")
+                from(dokkaHtml)
+            }
 
-        publishing {
-            publications {
-                create<MavenPublication>("default") {
-                    from(this@subprojects.components["java"])
-                    artifact(sourcesJar)
-                    artifact(javadocJar)
+            publishing {
+                publications {
+                    create<MavenPublication>("default") {
+                        from(this@subprojects.components["java"])
+                        artifact(sourcesJar)
+                        artifact(javadocJar)
 
-                    pom {
-                        name.set(project.name)
-                        description.set("Obsoleting enums with sealed classes of objects")
-                        url.set("https://github.com/livefront/sealed-enum")
-
-                        licenses {
-                            license {
-                                name.set("The Apache Software License, Version 2.0")
-                                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                                distribution.set("repo")
-                            }
-                        }
-
-                        developers {
-                            developer {
-                                id.set("alexvanyo")
-                                name.set("Alex Vanyo")
-                                organization.set("Livefront")
-                                organizationUrl.set("https://www.livefront.com")
-                            }
-                        }
-
-                        scm {
+                        pom {
+                            name.set(project.name)
+                            description.set("Obsoleting enums with sealed classes of objects")
                             url.set("https://github.com/livefront/sealed-enum")
-                            connection.set("scm:git:git://github.com/livefront/sealed-enum.git")
-                            developerConnection.set("scm:git:git://github.com/livefront/sealed-enum.git")
+
+                            licenses {
+                                license {
+                                    name.set("The Apache Software License, Version 2.0")
+                                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                                    distribution.set("repo")
+                                }
+                            }
+
+                            developers {
+                                developer {
+                                    id.set("alexvanyo")
+                                    name.set("Alex Vanyo")
+                                    organization.set("Livefront")
+                                    organizationUrl.set("https://www.livefront.com")
+                                }
+                            }
+
+                            scm {
+                                url.set("https://github.com/livefront/sealed-enum")
+                                connection.set("scm:git:git://github.com/livefront/sealed-enum.git")
+                                developerConnection.set("scm:git:git://github.com/livefront/sealed-enum.git")
+                            }
                         }
                     }
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.parallel=true
 kotlin.code.style=official
 
 group=com.livefront.sealedenum
-version=0.2.0
+version=0.3.0

--- a/processing-common/build.gradle.kts
+++ b/processing-common/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    `maven-publish`
+}
+
 dependencies {
     implementation(kotlin("stdlib"))
     implementation(project(":runtime"))

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("kapt")
+    `maven-publish`
 }
 
 dependencies {

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    `maven-publish`
+}
+
 dependencies {
     compileOnly(kotlin("stdlib"))
 


### PR DESCRIPTION
This PR prepares an `0.3.0` release, which includes the artifact rename to better support alternate generation strategies like KSP.