### PR TITLE
Restrict jcenter usage to kotlinx-html-jvm

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,12 @@ plugins {
 allprojects {
     repositories {
         mavenCentral()
-        jcenter()
+        jcenter {
+            content {
+                // TODO: https://github.com/Kotlin/kotlinx.html/issues/173
+                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Next PR in the saga of `jcenter`!

This restricts our usage of `jcenter` to the single library that still is only on `jcenter`, `kotlinx-html-jvm`:  https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-html-jvm

This will ensure we don't accidentally add a library that depends on `jcenter` without noticing, and when it's resolved, will allow us to remove `jcenter` cleanly. 