### PR TITLE
Update Dokka to 1.4.30

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Create documentation
         run: ./gradlew dokkaHtmlMultiModule
 
-      - name: Create index.html for GitHub Pages
-        run: cp ./build/dokka/htmlMultiModule/-modules.html ./build/dokka/htmlMultiModule/index.html
-
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val autoService = "1.0-rc7"
     const val detekt = "1.15.0"
-    const val dokka = "1.4.20"
+    const val dokka = "1.4.30"
     const val incap = "0.3"
     const val junit = "5.6.2"
     const val kotlin = "1.4.0"


### PR DESCRIPTION
A small update to [Dokka 1.4.30](https://github.com/Kotlin/dokka/releases/tag/v1.4.30), which improves output for multi-module documentation that this project uses. This also allows removing a workaround for the docs workflow, since `index.html` is now created directly.