### PR TITLE
Rename base branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to sealed-enum
 
-Contributions to the project are welcome! All external contributors should fork the repository and submit pull requests against the `master` branch. These must pass the checks run by CI and be reviewed and approved by a primary contributor before they can be merged. Prior to merging, the branch should be rebased with the latest changes from master and commits should be squashed where appropriate in order to cleanly encapsulate the final set of changes (i.e. no "Addressed review comment" commits should be present).
+Contributions to the project are welcome! All external contributors should fork the repository and submit pull requests against the `main` branch. These must pass the checks run by CI and be reviewed and approved by a primary contributor before they can be merged. Prior to merging, the branch should be rebased with the latest changes from `main` and commits should be squashed where appropriate in order to cleanly encapsulate the final set of changes (i.e. no "Addressed review comment" commits should be present).
 
 Please try to ensure that the project's existing code style and conventions are followed when making new contributions. To automate this process, this project uses [`detekt`](https://github.com/arturbosch/detekt) and its bundled `ktlint` for linting.


### PR DESCRIPTION
This PR updates `CONTRIBUTING.md` to reflect the updated default base branch name of `main`.