### PR TITLE
Update jacoco and allow CI to run on Java 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
           - 12
           - 13
           - 14
-        # - 15 TODO: Include JDK 15 when we can update JaCoCo to 0.8.7
+          - 15
+          # - 16 TODO: Include JDK 16 when kapt supports it: https://youtrack.jetbrains.com/issue/KT-45545
 
     steps:
       - name: Checkout

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,10 @@ subprojects {
             useJUnitPlatform()
         }
 
+        jacoco {
+            toolVersion = Versions.jacoco
+        }
+
         jacocoTestReport {
             dependsOn(test)
 
@@ -123,6 +127,10 @@ subprojects {
             }
         }
     }
+}
+
+jacoco {
+    toolVersion = Versions.jacoco
 }
 
 apiValidation {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,7 @@
 object Versions {
     const val detekt = "1.17.0-RC2"
     const val dokka = "1.4.32"
+    const val jacoco = "0.8.7"
     const val kotlin = "1.4.0"
     const val kotlinBinaryCompatibilityValidator = "0.4.0"
 }


### PR DESCRIPTION
[JaCoCo 0.8.7](https://github.com/jacoco/jacoco/releases/tag/v0.8.7) was just released, which means we can update CI to run on JDK 15 as well. JaCoCo 0.8.7 also supports JDK 16, but we are blocked on `kapt` supporting that: https://youtrack.jetbrains.com/issue/KT-45545