### PR TITLE
Remove jcenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,6 @@ plugins {
 allprojects {
     repositories {
         mavenCentral()
-        jcenter {
-            content {
-                // TODO: https://github.com/Kotlin/kotlinx.html/issues/173
-                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
-            }
-        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     const val detekt = "1.15.0"
-    const val dokka = "1.4.30"
+    const val dokka = "1.4.32"
     const val kotlin = "1.4.0"
     const val kotlinBinaryCompatibilityValidator = "0.4.0"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val detekt = "1.15.0"
+    const val detekt = "1.17.0-RC2"
     const val dokka = "1.4.32"
     const val kotlin = "1.4.0"
     const val kotlinBinaryCompatibilityValidator = "0.4.0"

--- a/runtime/src/test/kotlin/com/livefront/sealedenum/CreateSealedEnumFromEnumTests.kt
+++ b/runtime/src/test/kotlin/com/livefront/sealedenum/CreateSealedEnumFromEnumTests.kt
@@ -54,7 +54,6 @@ class CreateSealedEnumFromEnumTests {
                     ComparatorConfig(AlphaEnum.DELTA, AlphaEnum.GAMMA, 1),
                     ComparatorConfig(AlphaEnum.DELTA, AlphaEnum.DELTA, 0)
                 ).map { Arguments.of(it) }.stream()
-
         }
     }
 


### PR DESCRIPTION
This PR updates detekt and dokka. The latest versions of these bumped their dependency on `kotlinx-html-jvm`, which was the last dependency we were pulling from `jcenter`.

This allows us to remove `jcenter` completely, fixing #47 .