### PR TITLE
Update detekt to 1.17.0

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val detekt = "1.17.0-RC2"
+    const val detekt = "1.17.0"
     const val dokka = "1.4.32"
     const val jacoco = "0.8.7"
     const val kotlin = "1.4.0"


### PR DESCRIPTION
A version bump off of the release candidate for deket to 1.17.0