### PR TITLE
Update kotlin binary compatibility validator to 0.5.0

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,5 +3,5 @@ object Versions {
     const val dokka = "1.4.32"
     const val jacoco = "0.8.7"
     const val kotlin = "1.4.0"
-    const val kotlinBinaryCompatibilityValidator = "0.4.0"
+    const val kotlinBinaryCompatibilityValidator = "0.5.0"
 }


### PR DESCRIPTION
A bump to Kotlin binary compatibility validator to 0.5.0