### PR TITLE
Remove explicit stdlib inclusion

### DIFF
--- a/processing-common/build.gradle.kts
+++ b/processing-common/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation(projects.runtime)
     implementation(libs.squareUp.kotlinPoet)
 

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation(projects.runtime)
     implementation(projects.processingCommon)
     implementation(libs.squareUp.kotlinPoet)

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -3,8 +3,5 @@ plugins {
 }
 
 dependencies {
-    compileOnly(kotlin("stdlib"))
-
-    testImplementation(kotlin("stdlib"))
     testImplementation(libs.junit.jupiter)
 }


### PR DESCRIPTION
A small PR to remove the explicit inclusion of the Kotlin `stdlib`, which isn't necessary since 1.4. This also helps avoiding some weird versioning as Kotlin versions update.