### PR TITLE
Add type resolution for detekt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,10 @@ subprojects {
             jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
 
+        check {
+            dependsOn("detektMain")
+        }
+
         dokkaHtml {
             outputDirectory.set(javadoc.get().destinationDir)
         }

--- a/processing-common/src/main/kotlin/com/livefront/sealedenum/internal/common/spec/SealedEnumFileSpec.kt
+++ b/processing-common/src/main/kotlin/com/livefront/sealedenum/internal/common/spec/SealedEnumFileSpec.kt
@@ -131,6 +131,7 @@ public data class SealedEnumFileSpec(
 
         fileSpecBuilder.addType(enumForSealedEnumTypeSpec)
 
+        @Suppress("UnsafeCallOnNullableType") // Generated enum will have a non-null name
         val enumForSealedEnumClassName =
             ClassName(sealedClass.packageName, enumForSealedEnumTypeSpec.name!!)
 

--- a/processor/src/main/kotlin/com/livefront/sealedenum/internal/processor/SealedEnumProcessor.kt
+++ b/processor/src/main/kotlin/com/livefront/sealedenum/internal/processor/SealedEnumProcessor.kt
@@ -201,6 +201,7 @@ public class SealedEnumProcessor : AbstractProcessor() {
             sealedClassNode = sealedClassNode,
             sealedEnumOptions = sealedEnumAnnotations.associate {
                 it.traversalOrder to if (it.generateEnum) {
+                    @Suppress("UnsafeCallOnNullableType") // Guaranteed safe by above any call
                     SealedEnumWithEnum(sealedClassInterfaces!!)
                 } else {
                     SealedEnumOnly


### PR DESCRIPTION
Adds `detektMain` to `check`, which applies addition type-resolving linting rules.

Only two currently disobeyed are `UnsafeCallOnNullableType`, which are guaranteed to not be `null`.