### PR TITLE
Update kotlin-compile-testing to 1.4.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 autoService = "1.0"
 incap = "0.3"
 junit = "5.7.0"
-kotlinCompileTesting = "1.4.3"
+kotlinCompileTesting = "1.4.4"
 kotlinPoet = "1.9.0"
 ksp = "1.5.30-1.0.0"
 


### PR DESCRIPTION
Version bump of `kotlin-compile-testing` to `1.4.4`, the latest as of now.