### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
+# 0.4.0
+## Features:
+- Added full support for `sealed interface`s
+- Added [KSP](https://github.com/google/ksp) processor as an alternate code generation method 
+
+## Miscellaneous updates:
+- Update to Kotlin 1.5
+- Add binary compatibility validator
+- Added JDK 15 to CI tests
+- Added CI to run on macOS and Windows
+- Various dependency updates
+
 # 0.3.0
 ## Breaking changes:
 - Artifact ids were updated (`sealedenum` -> `runtime` and `sealedenumprocessor` -> `processor`).
-  This was done to accomodate alternate generation implementations, such as by [KSP](https://github.com/google/ksp)
+  This was done to accommodate alternate generation implementations, such as by [KSP](https://github.com/google/ksp)
 
 ## Miscellaneous updates:
 - Switch to GitHub actions for CI

--- a/README.md
+++ b/README.md
@@ -353,8 +353,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.livefront.sealed-enum:runtime:0.3.0")
-    kapt("com.github.livefront.sealed-enum:processor:0.3.0")
+    implementation("com.github.livefront.sealed-enum:runtime:0.4.0")
+    kapt("com.github.livefront.sealed-enum:processor:0.4.0")
 }
 ```
 
@@ -362,7 +362,7 @@ dependencies {
 
 ```kotlin
 plugins {
-    id("com.google.devtools.ksp") version "1.5.21-1.0.0-beta07"
+    id("com.google.devtools.ksp") version "1.5.30-1.0.0-beta09"
 }
 
 repositories {
@@ -370,8 +370,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.livefront.sealed-enum:runtime:0.3.0")
-    ksp("com.github.livefront.sealed-enum:ksp:0.3.0")
+    implementation("com.github.livefront.sealed-enum:runtime:0.4.0")
+    ksp("com.github.livefront.sealed-enum:ksp:0.4.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.parallel=true
 kotlin.code.style=official
 
 group=com.livefront.sealedenum
-version=0.3.0
+version=0.4.0


### PR DESCRIPTION
Prepares the project for a `0.4.0` release, which mainly adds support for KSP and full support for `sealed interface`s.