### PR TITLE
Update KotlinPoet to 1.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ autoService = "1.0"
 incap = "0.3"
 junit = "5.7.0"
 kotlinCompileTesting = "1.4.3"
-kotlinPoet = "1.8.0"
+kotlinPoet = "1.9.0"
 ksp = "1.5.30-1.0.0"
 
 [libraries]

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClass.kt
@@ -23,7 +23,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [EmptySealedClass]
  */
-public enum class EmptySealedClassEnum
+public enum class EmptySealedClassEnum()
 
 /**
  * The isomorphic [EmptySealedClassEnum] for [this].

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedInterface.kt
@@ -23,7 +23,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [EmptySealedInterface]
  */
-public enum class EmptySealedInterfaceEnum
+public enum class EmptySealedInterfaceEnum()
 
 /**
  * The isomorphic [EmptySealedInterfaceEnum] for [this].

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClass.kt
@@ -25,7 +25,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [OneObjectSealedClass]
  */
-public enum class OneObjectSealedClassEnum {
+public enum class OneObjectSealedClassEnum() {
     OneObjectSealedClass_FirstObject,
 }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedInterface.kt
@@ -25,7 +25,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [OneObjectSealedInterface]
  */
-public enum class OneObjectSealedInterfaceEnum {
+public enum class OneObjectSealedInterfaceEnum() {
     OneObjectSealedInterface_FirstObject,
 }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClass.kt
@@ -27,7 +27,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [TwoObjectSealedClass]
  */
-public enum class TwoObjectSealedClassEnum {
+public enum class TwoObjectSealedClassEnum() {
     TwoObjectSealedClass_FirstObject,
     TwoObjectSealedClass_SecondObject,
 }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedInterface.kt
@@ -27,7 +27,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [TwoObjectSealedInterface]
  */
-public enum class TwoObjectSealedInterfaceEnum {
+public enum class TwoObjectSealedInterfaceEnum() {
     TwoObjectSealedInterface_FirstObject,
     TwoObjectSealedInterface_SecondObject,
 }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
@@ -31,7 +31,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [OneTypeParameterSealedClass]
  */
-public enum class OneTypeParameterSealedClassEnum {
+public enum class OneTypeParameterSealedClassEnum() {
     OneTypeParameterSealedClass_FirstObject,
     OneTypeParameterSealedClass_SecondObject,
     OneTypeParameterSealedClass_ThirdObject,
@@ -166,7 +166,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [TwoTypeParameterSealedClass]
  */
-public enum class TwoTypeParameterSealedClassEnum {
+public enum class TwoTypeParameterSealedClassEnum() {
     TwoTypeParameterSealedClass_FirstObject,
     TwoTypeParameterSealedClass_SecondObject,
 }
@@ -293,7 +293,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [LimitedTypeParameterSealedClass]
  */
-public enum class LimitedTypeParameterSealedClassEnum {
+public enum class LimitedTypeParameterSealedClassEnum() {
     LimitedTypeParameterSealedClass_FirstObject,
     LimitedTypeParameterSealedClass_SecondObject,
 }
@@ -429,7 +429,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [MultipleBoundsSealedClass]
  */
-public enum class MultipleBoundsSealedClassEnum {
+public enum class MultipleBoundsSealedClassEnum() {
     MultipleBoundsSealedClass_FirstObject,
 }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
@@ -34,7 +34,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [FirstClassHierarchy.A]
  */
-public enum class FirstClassHierarchy_AEnum {
+public enum class FirstClassHierarchy_AEnum() {
     FirstClassHierarchy_A_B_C,
 }
 
@@ -138,7 +138,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [FirstClassHierarchy.A.B]
  */
-public enum class FirstClassHierarchy_A_BEnum {
+public enum class FirstClassHierarchy_A_BEnum() {
     FirstClassHierarchy_A_B_C,
 }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedInterfaceHierarchy.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedInterfaceHierarchy.kt
@@ -34,7 +34,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [FirstInterfaceHierarchy.A]
  */
-public enum class FirstInterfaceHierarchy_AEnum {
+public enum class FirstInterfaceHierarchy_AEnum() {
     FirstInterfaceHierarchy_A_B_C,
 }
 
@@ -138,7 +138,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [FirstInterfaceHierarchy.A.B]
  */
-public enum class FirstInterfaceHierarchy_A_BEnum {
+public enum class FirstInterfaceHierarchy_A_BEnum() {
     FirstInterfaceHierarchy_A_B_C,
 }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
@@ -25,7 +25,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [AlphaOutsideSealedClass]
  */
-public enum class AlphaOutsideSealedClassEnum {
+public enum class AlphaOutsideSealedClassEnum() {
     AlphaFirstObject,
 }
 
@@ -138,7 +138,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [BetaOutsideSealedClass]
  */
-public enum class BetaOutsideSealedClassEnum {
+public enum class BetaOutsideSealedClassEnum() {
     BetaFirstObject,
     BetaSecondObject,
 }
@@ -261,7 +261,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [GammaOutsideSealedClass]
  */
-public enum class GammaOutsideSealedClassEnum {
+public enum class GammaOutsideSealedClassEnum() {
     GammaFirstObject,
     GammaOutsideSealedClass_GammaSecondObject,
     GammaThirdObject,
@@ -390,7 +390,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [DeltaOutsideSealedClass]
  */
-public enum class DeltaOutsideSealedClassEnum {
+public enum class DeltaOutsideSealedClassEnum() {
     DeltaOutsideSealedClass_DeltaObject,
     DeltaObject,
 }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/SplitAcrossFilesSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/SplitAcrossFilesSealedClass.kt
@@ -24,7 +24,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [SplitAcrossFilesSealedClass]
  */
-public enum class SplitAcrossFilesSealedClassEnum {
+public enum class SplitAcrossFilesSealedClassEnum() {
     SplitAcrossFilesSubclassA,
     SplitAcrossFilesSubclassB,
     SplitAcrossFilesSubclassC,

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
@@ -76,7 +76,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [Tree]
  */
-public enum class TreeLevelOrderEnum {
+public enum class TreeLevelOrderEnum() {
     Tree_A,
     Tree_K,
     Tree_T,
@@ -253,7 +253,7 @@ public fun Tree.Companion.levelOrderValueOf(name: String): Tree =
 /**
  * An isomorphic enum for the sealed class [Tree]
  */
-public enum class TreePostOrderEnum {
+public enum class TreePostOrderEnum() {
     Tree_B_C_F_G,
     Tree_B_C_F_H,
     Tree_B_C_F_I,
@@ -430,7 +430,7 @@ public fun Tree.Companion.postOrderValueOf(name: String): Tree =
 /**
  * An isomorphic enum for the sealed class [Tree]
  */
-public enum class TreeInOrderEnum {
+public enum class TreeInOrderEnum() {
     Tree_A,
     Tree_B_C_D,
     Tree_B_C_E,
@@ -606,7 +606,7 @@ public fun Tree.Companion.inOrderValueOf(name: String): Tree = TreeInOrderSealed
 /**
  * An isomorphic enum for the sealed class [Tree]
  */
-public enum class TreePreOrderEnum {
+public enum class TreePreOrderEnum() {
     Tree_A,
     Tree_K,
     Tree_T,

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/PrivateInterfaceSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/PrivateInterfaceSealedClass.kt
@@ -31,7 +31,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [PrivateInterfaceSealedClass]
  */
-public enum class PrivateInterfaceSealedClassEnum {
+public enum class PrivateInterfaceSealedClassEnum() {
     PrivateInterfaceSealedClass_FirstObject,
     PrivateInterfaceSealedClass_SecondObject,
 }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClass.kt
@@ -39,7 +39,7 @@ import kotlin.collections.List
  * [ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass]
  */
 public enum class
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum
+        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum()
         {
     ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_FirstObject,
     ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_SecondObject,

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
@@ -31,7 +31,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [InternalObjectsSealedClass]
  */
-public enum class InternalObjectsSealedClassEnum {
+public enum class InternalObjectsSealedClassEnum() {
     InternalObjectsSealedClass_FirstObject,
     InternalObjectsSealedClass_SecondObject,
     InternalObjectsSealedClass_InnerSealedClass_ThirdObject,
@@ -166,7 +166,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [InternalSealedClass]
  */
-internal enum class InternalSealedClassEnum {
+internal enum class InternalSealedClassEnum() {
     InternalSealedClass_FirstObject,
     InternalSealedClass_SecondObject,
 }
@@ -286,7 +286,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [InternalCompanionSealedClass]
  */
-public enum class InternalCompanionSealedClassEnum {
+public enum class InternalCompanionSealedClassEnum() {
     InternalCompanionSealedClass_FirstObject,
     InternalCompanionSealedClass_SecondObject,
 }
@@ -411,7 +411,7 @@ import kotlin.collections.List
 /**
  * An isomorphic enum for the sealed class [InternalSealedAndCompanionSealedClass]
  */
-internal enum class InternalSealedAndCompanionSealedClassEnum {
+internal enum class InternalSealedAndCompanionSealedClassEnum() {
     InternalSealedAndCompanionSealedClass_FirstObject,
     InternalSealedAndCompanionSealedClass_SecondObject,
 }


### PR DESCRIPTION
Updates KotlinPoet to latest.

The only code generation adjustment was adding the default constructor call to all generated `enum class`es, which is unnecessary but fine to include.

Fixes #84 