### PR TITLE
Cancel in progress builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
 
+    concurrency:
+      group: ci-${{ github.event_name }}-${{ github.ref }}-${{ matrix.java-version }}-${{ matrix.os }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A small GitHub Actions change, as specified here: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

This is primarily useful to automatically cancel jobs while updating PRs repeatedly in short succession, especially since macOS and Windows builds take quite a bit of time (and the number of parallel jobs is limited).

One note: this could cancel a `main` job if two PRs were merged right after each other, but that's fine: the checks with the final merge would eventually get run.