### PR TITLE
Add nested objects test for KSP

### DIFF
--- a/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameName.kt
+++ b/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameName.kt
@@ -1,0 +1,124 @@
+package com.livefront.sealedenum.compilation.ksp
+
+import com.livefront.sealedenum.GenSealedEnum
+import org.intellij.lang.annotations.Language
+
+@Suppress("UtilityClassWithPublicConstructor")
+class NestedObjectsWithSameName {
+    companion object {
+        sealed class EmptySealedClass {
+            @GenSealedEnum(generateEnum = true)
+            companion object
+        }
+    }
+}
+
+@Language("kotlin")
+val nestedObjectsWithSameNameEmptySealedClassGenerated = """
+package com.livefront.sealedenum.compilation.ksp
+
+import com.livefront.sealedenum.EnumForSealedEnumProvider
+import com.livefront.sealedenum.SealedEnum
+import com.livefront.sealedenum.SealedEnumWithEnumProvider
+import java.lang.Class
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+/**
+ * An isomorphic enum for the sealed class [NestedObjectsWithSameName.Companion.EmptySealedClass]
+ */
+public enum class NestedObjectsWithSameName_Companion_EmptySealedClassEnum()
+
+/**
+ * The isomorphic [NestedObjectsWithSameName_Companion_EmptySealedClassEnum] for [this].
+ */
+public val NestedObjectsWithSameName.Companion.EmptySealedClass.`enum`:
+        NestedObjectsWithSameName_Companion_EmptySealedClassEnum
+    get() = NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum.sealedObjectToEnum(this)
+
+/**
+ * The isomorphic [NestedObjectsWithSameName.Companion.EmptySealedClass] for [this].
+ */
+public val NestedObjectsWithSameName_Companion_EmptySealedClassEnum.sealedObject:
+        NestedObjectsWithSameName.Companion.EmptySealedClass
+    get() = NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum.enumToSealedObject(this)
+
+/**
+ * An implementation of [SealedEnum] for the sealed class
+ * [NestedObjectsWithSameName.Companion.EmptySealedClass]
+ */
+public object NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum :
+        SealedEnum<NestedObjectsWithSameName.Companion.EmptySealedClass>,
+        SealedEnumWithEnumProvider<NestedObjectsWithSameName.Companion.EmptySealedClass,
+        NestedObjectsWithSameName_Companion_EmptySealedClassEnum>,
+        EnumForSealedEnumProvider<NestedObjectsWithSameName.Companion.EmptySealedClass,
+        NestedObjectsWithSameName_Companion_EmptySealedClassEnum> {
+    public override val values: List<NestedObjectsWithSameName.Companion.EmptySealedClass> =
+            emptyList()
+
+
+    public override val enumClass: Class<NestedObjectsWithSameName_Companion_EmptySealedClassEnum>
+        get() = NestedObjectsWithSameName_Companion_EmptySealedClassEnum::class.java
+
+    public override fun ordinalOf(obj: NestedObjectsWithSameName.Companion.EmptySealedClass): Int =
+            throw
+            AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")
+
+    public override fun nameOf(obj: NestedObjectsWithSameName.Companion.EmptySealedClass): String =
+            throw
+            AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")
+
+    public override fun valueOf(name: String): NestedObjectsWithSameName.Companion.EmptySealedClass
+            = throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
+
+    public override
+            fun sealedObjectToEnum(obj: NestedObjectsWithSameName.Companion.EmptySealedClass):
+            NestedObjectsWithSameName_Companion_EmptySealedClassEnum = throw
+            AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")
+
+    public override
+            fun enumToSealedObject(`enum`: NestedObjectsWithSameName_Companion_EmptySealedClassEnum):
+            NestedObjectsWithSameName.Companion.EmptySealedClass = throw
+            AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")
+}
+
+/**
+ * The index of [this] in the values list.
+ */
+public val NestedObjectsWithSameName.Companion.EmptySealedClass.ordinal: Int
+    get() = NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum.ordinalOf(this)
+
+/**
+ * The name of [this] for use with valueOf.
+ */
+public val NestedObjectsWithSameName.Companion.EmptySealedClass.name: String
+    get() = NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum.nameOf(this)
+
+/**
+ * A list of all [NestedObjectsWithSameName.Companion.EmptySealedClass] objects.
+ */
+public val NestedObjectsWithSameName.Companion.EmptySealedClass.Companion.values:
+        List<NestedObjectsWithSameName.Companion.EmptySealedClass>
+    get() = NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum.values
+
+/**
+ * Returns an implementation of [SealedEnum] for the sealed class
+ * [NestedObjectsWithSameName.Companion.EmptySealedClass]
+ */
+public val NestedObjectsWithSameName.Companion.EmptySealedClass.Companion.sealedEnum:
+        NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum
+    get() = NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum
+
+/**
+ * Returns the [NestedObjectsWithSameName.Companion.EmptySealedClass] object for the given [name].
+ *
+ * If the given name doesn't correspond to any
+ * [NestedObjectsWithSameName.Companion.EmptySealedClass], an [IllegalArgumentException] will be
+ * thrown.
+ */
+public fun NestedObjectsWithSameName.Companion.EmptySealedClass.Companion.valueOf(name: String):
+        NestedObjectsWithSameName.Companion.EmptySealedClass =
+        NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum.valueOf(name)
+
+""".trimIndent()

--- a/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameNameTests.kt
+++ b/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameNameTests.kt
@@ -1,0 +1,58 @@
+package com.livefront.sealedenum.compilation.ksp
+
+import com.livefront.sealedenum.testing.assertCompiles
+import com.livefront.sealedenum.testing.assertGeneratedFileMatches
+import com.livefront.sealedenum.testing.compile
+import com.livefront.sealedenum.testing.getSourceFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that a sealed class in a companion object (or more precisely, an annotation that appears on a nested object
+ * with the same name) still generates a sealed enum.
+ *
+ * Note that this only works with KSP, due to a limitation with KAPT.
+ * Because the generated stubs for such an object wouldn't be valid Java, they are skipped, meaning that the annotation
+ * wouldn't be processed.
+ *
+ * @see <a href="https://github.com/livefront/sealed-enum/issues/60">sealed-enum/issues/60</a>
+ */
+class NestedObjectsWithSameNameTests {
+    @Test
+    fun `empty sealed class`() {
+        assertEquals(
+            emptyList<NestedObjectsWithSameName.Companion.EmptySealedClass>(),
+            NestedObjectsWithSameName.Companion.EmptySealedClass.values
+        )
+    }
+
+    @Test
+    fun `empty enum for sealed class`() {
+        assertEquals(
+            NestedObjectsWithSameName.Companion.EmptySealedClass.values.map(
+                NestedObjectsWithSameName.Companion.EmptySealedClass::enum
+            ),
+            enumValues<NestedObjectsWithSameName_Companion_EmptySealedClassEnum>().toList()
+        )
+    }
+
+    @Test
+    fun `correct enum class`() {
+        assertEquals(
+            NestedObjectsWithSameName_Companion_EmptySealedClassEnum::class.java,
+            NestedObjectsWithSameName.Companion.EmptySealedClass.sealedEnum.enumClass
+        )
+    }
+
+    @Test
+    fun `compilation generates correct code`() {
+        val result = compile(getSourceFile("compilation", "ksp", "NestedObjectsWithSameName.kt"))
+
+        assertCompiles(result)
+        assertGeneratedFileMatches(
+            "NestedObjectsWithSameName.Companion.EmptySealedClass_SealedEnum.kt",
+            nestedObjectsWithSameNameEmptySealedClassGenerated,
+            result
+        )
+    }
+}


### PR DESCRIPTION
Adds a KSP-specific test for a sealed class that is contained inside a `companion object`.

With the default `Companion` name for both `companion object`s, this won't work with KAPT, since the generated stubs aren't valid Java. Since this is perfectly valid Kotlin though, KSP has no issue.

This fixes #60 