### PR TITLE
Update dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
-    const val detekt = "1.17.0"
-    const val dokka = "1.4.32"
+    const val detekt = "1.18.1"
+    const val dokka = "1.5.31"
     const val jacoco = "0.8.7"
-    const val kotlin = "1.5.30"
-    const val kotlinBinaryCompatibilityValidator = "0.5.0"
+    const val kotlin = "1.5.31"
+    const val kotlinBinaryCompatibilityValidator = "0.7.1"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 autoService = "1.0"
 incap = "0.3"
-junit = "5.7.0"
-kotlinCompileTesting = "1.4.4"
+junit = "5.8.1"
+kotlinCompileTesting = "1.4.5"
 kotlinPoet = "1.10.1"
-ksp = "1.5.30-1.0.0"
+ksp = "1.5.31-1.0.0"
 
 [libraries]
 autoService-runtime = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
     }
 
     plugins {
-        id("com.google.devtools.ksp") version "1.5.30-1.0.0"
+        id("com.google.devtools.ksp") version "1.5.31-1.0.0"
     }
 }
 


### PR DESCRIPTION
A version bump of dependencies to latest:

- Kotlin to `1.5.31`
- KSP to `1.5.31-1.0.0`
- kotlin-compile-testing to `1.4.5`
- detekt to `1.18.1`
- JUnit to `5.8.1`
- kotlin-binary-compatibility-validator to `0.7.1`