### PR TITLE
Update to Gradle 7.2 and remove buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    kotlin("jvm") version Versions.kotlin
+    alias(libs.plugins.kotlin.jvm)
     jacoco
-    id("io.gitlab.arturbosch.detekt") version Versions.detekt
-    id("org.jetbrains.dokka") version Versions.dokka
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version Versions.kotlinBinaryCompatibilityValidator
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.kotlinxBinaryCompatibilityValidator)
     `maven-publish`
 }
 
@@ -24,7 +24,7 @@ subprojects {
     }
 
     dependencies {
-        detektPlugins(Dependencies.detektFormatting)
+        detektPlugins(rootProject.libs.detekt.formatting)
     }
 
     java {
@@ -58,7 +58,7 @@ subprojects {
         }
 
         jacoco {
-            toolVersion = Versions.jacoco
+            toolVersion = rootProject.libs.versions.jacoco.get()
         }
 
         jacocoTestReport {
@@ -136,7 +136,7 @@ subprojects {
 }
 
 jacoco {
-    toolVersion = Versions.jacoco
+    toolVersion = libs.versions.jacoco.get()
 }
 
 apiValidation {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,8 +65,8 @@ subprojects {
             dependsOn(test)
 
             reports {
-                html.isEnabled = true
-                xml.isEnabled = true
+                html.required.set(true)
+                xml.required.set(true)
             }
         }
 
@@ -144,23 +144,19 @@ apiValidation {
 }
 
 tasks {
-    val jacocoMergeTest by registering(JacocoMerge::class) {
-        dependsOn(subprojects.map { it.tasks.jacocoTestReport })
-
-        destinationFile = file("$buildDir/jacoco/test.exec")
-        executionData = fileTree(rootDir) {
-            include("**/build/jacoco/test.exec")
-        }
-    }
-
     jacocoTestReport {
-        dependsOn(jacocoMergeTest)
-
+        dependsOn(subprojects.map { it.tasks.jacocoTestReport })
         sourceSets(*subprojects.map { it.sourceSets.main.get() }.toTypedArray())
 
+        executionData.setFrom(
+            fileTree(rootDir) {
+                include("**/build/jacoco/test.exec")
+            }
+        )
+
         reports {
-            html.isEnabled = true
-            xml.isEnabled = true
+            html.required.set(true)
+            xml.required.set(true)
         }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-    `kotlin-dsl`
-}
-
-repositories {
-    mavenCentral()
-}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,3 +1,0 @@
-object Dependencies {
-    const val detektFormatting = "io.gitlab.arturbosch.detekt:detekt-formatting:${Versions.detekt}"
-}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,0 @@
-object Versions {
-    const val detekt = "1.18.1"
-    const val dokka = "1.5.31"
-    const val jacoco = "0.8.7"
-    const val kotlin = "1.5.31"
-    const val kotlinBinaryCompatibilityValidator = "0.7.1"
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,12 @@
 [versions]
 autoService = "1.0"
+detekt = "1.18.1"
+dokka = "1.5.31"
 incap = "0.3"
+jacoco = "0.8.7"
 junit = "5.8.1"
+kotlin = "1.5.31"
+kotlinxBinaryCompatibilityValidator = "0.7.1"
 kotlinCompileTesting = "1.4.5"
 kotlinPoet = "1.10.1"
 ksp = "1.5.31-1.0.0"
@@ -9,6 +14,8 @@ ksp = "1.5.31-1.0.0"
 [libraries]
 autoService-runtime = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 autoService-processor = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
+
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt"}
 
 incap-runtime = { module = "net.ltgt.gradle.incap:incap", version.ref = "incap" }
 incap-processor = { module = "net.ltgt.gradle.incap:incap-processor", version.ref = "incap" }
@@ -24,3 +31,10 @@ squareUp-kotlinPoetMetadata = { module = "com.squareup:kotlinpoet-metadata", ver
 
 ksp-runtime = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+
+[plugins]
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinxBinaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinxBinaryCompatibilityValidator" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/processing-tests/ksp-tests/build.gradle.kts
+++ b/processing-tests/ksp-tests/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.google.devtools.ksp")
+    alias(libs.plugins.ksp)
     idea
 }
 

--- a/processing-tests/ksp-tests/build.gradle.kts
+++ b/processing-tests/ksp-tests/build.gradle.kts
@@ -19,7 +19,7 @@ if (!debugProcessor) {
 }
 
 detekt {
-    input = files(
+    source = files(
         "src/main/java",
         "src/test/java",
         "src/main/kotlin",

--- a/processing-tests/processor-tests/build.gradle.kts
+++ b/processing-tests/processor-tests/build.gradle.kts
@@ -19,7 +19,7 @@ if (!debugKsp) {
 }
 
 detekt {
-    input = files(
+    source = files(
         "src/main/java",
         "src/test/java",
         "src/main/kotlin",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,17 +1,6 @@
 enableFeaturePreview("VERSION_CATALOGS")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-
-    plugins {
-        id("com.google.devtools.ksp") version "1.5.31-1.0.0"
-    }
-}
-
 include(":runtime")
 include(":processing-common")
 include(":processor")


### PR DESCRIPTION
This PR updates to Gradle 7.2, which allows using version catalogs in even more places.

This allows us to fully remove `buildSrc`, which was only used for the hold-out version declarations, and consolidate all dependencies into `libs.versions.toml`.

I also updated the build scripts to replace any newly deprecated issues caused by the upgrade of Gradle to 7.2.