### PR TITLE
Update to Kotlin 1.7.0 and fix declaration ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,13 @@ val Alpha.Companion.inOrderSealedEnum: AlphaInOrderSealedEnum
 fun Alpha.Companion.inOrderValueOf(name: String): Alpha = AlphaInOrderSealedEnum.valueOf(name)
 ```
 
+The traversal order is guaranteed to be in declaration order when the source code is nested within the sealed class.
+Sealed subclasses, however, can also be defined elsewhere in the file and package.
+
+In the general case, the default order of sealed subclasses is:
+- In source declaration order when declared as inner classes within the sealed class.
+- In qualified-name alphabetical order when not declared as an inner class within the sealed class.  
+
 The runtime library includes support from creating a `SealedEnum` from a normal enum class, with `createSealedEnumFromEnum()` and `createSealedEnumFromEnumArray(values: Array<E>, enumClass: Class<E>)`.
 
 If `generateEnum` is set to `true` on the `@GenSealedEnum` annotation, then an isomorphic enum class will be generated for the sealed class.

--- a/build-logic/convention/src/main/kotlin/com.livefront.sealedenum.kotlin.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/com.livefront.sealedenum.kotlin.gradle.kts
@@ -35,7 +35,7 @@ tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         kotlinOptions {
             allWarningsAsErrors = true
-            freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+            freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
         }
     }
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -472,7 +472,7 @@ potential-bugs:
   LateinitUsage:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    excludeAnnotatedProperties: []
+    ignoreAnnotated: []
     ignoreOnClassesPattern: ''
   MapGetWithNotNullAssertionOperator:
     active: false
@@ -541,7 +541,7 @@ style:
     active: true
     ignoreOverridableFunction: true
     excludedFunctions: 'describeContents'
-    excludeAnnotatedFunction: ['dagger.Provides']
+    ignoreAnnotated: ['dagger.Provides']
   LibraryCodeMustSpecifyReturnType:
     active: true
   LibraryEntitiesShouldNotBePublic:
@@ -617,10 +617,10 @@ style:
     active: false
   UnderscoresInNumericLiterals:
     active: false
-    acceptableDecimalLength: 5
+    acceptableLength: 5
   UnnecessaryAbstractClass:
     active: true
-    excludeAnnotatedClasses: ['dagger.Module']
+    ignoreAnnotated: ['dagger.Module']
   UnnecessaryAnnotationUseSiteTarget:
     active: false
   UnnecessaryApply:
@@ -648,7 +648,7 @@ style:
     active: false
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: []
+    ignoreAnnotated: []
     allowVars: false
   UseEmptyCounterpart:
     active: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,11 +5,11 @@ dokka = "1.5.31"
 incap = "0.3"
 jacoco = "0.8.7"
 junit = "5.8.1"
-kotlin = "1.5.31"
-kotlinxBinaryCompatibilityValidator = "0.7.1"
-kotlinCompileTesting = "1.4.5"
+kotlin = "1.6.21"
+kotlinxBinaryCompatibilityValidator = "0.11.0"
+kotlinCompileTesting = "1.4.8"
 kotlinPoet = "1.10.1"
-ksp = "1.5.31-1.0.0"
+ksp = "1.6.21-1.0.6"
 
 [libraries]
 autoService-runtime = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 autoService = "1.0"
-detekt = "1.18.1"
-dokka = "1.5.31"
+detekt = "1.20.0"
+dokka = "1.7.0"
 incap = "0.3"
 jacoco = "0.8.7"
 junit = "5.8.1"
-kotlin = "1.6.21"
+kotlin = "1.7.0"
 kotlinxBinaryCompatibilityValidator = "0.11.0"
-kotlinCompileTesting = "1.4.8"
-kotlinPoet = "1.10.1"
-ksp = "1.6.21-1.0.6"
+kotlinCompileTesting = "1.4.9"
+kotlinPoet = "1.12.0"
+ksp = "1.7.0-1.0.6"
 
 [libraries]
 autoService-runtime = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/ksp/src/main/kotlin/com/livefront/sealedenum/internal/ksp/KotlinPoetKsp.kt
+++ b/ksp/src/main/kotlin/com/livefront/sealedenum/internal/ksp/KotlinPoetKsp.kt
@@ -5,11 +5,9 @@ import com.google.devtools.ksp.symbol.Variance
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeName
-import com.squareup.kotlinpoet.ksp.KotlinPoetKspPreview
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 
-@OptIn(KotlinPoetKspPreview::class)
 internal fun KSClassDeclaration.toTypeName(argumentList: List<TypeName> = emptyList()): TypeName {
     val className = toClassName()
     return if (argumentList.isNotEmpty()) {
@@ -28,7 +26,6 @@ internal fun KSClassDeclaration.toTypeName(argumentList: List<TypeName> = emptyL
  * In particular, single invariant types can be replaced with the type directly. In all other cases (multiple bounds,
  * other types of variance) the only thing we can do is wildcard the type.
  */
-@OptIn(KotlinPoetKspPreview::class)
 internal fun KSClassDeclaration.wildcardedTypeNames(): List<TypeName> =
     typeParameters.map {
         val bounds = it.bounds.toList()

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
@@ -187,9 +187,9 @@ public val TwoTypeParameterSealedClassEnum.sealedObject: TwoTypeParameterSealedC
  * An implementation of [SealedEnum] for the sealed class [TwoTypeParameterSealedClass]
  */
 public object TwoTypeParameterSealedClassSealedEnum : SealedEnum<TwoTypeParameterSealedClass<*, *>>,
-        SealedEnumWithEnumProvider<TwoTypeParameterSealedClass<*, *>,
-        TwoTypeParameterSealedClassEnum>, EnumForSealedEnumProvider<TwoTypeParameterSealedClass<*,
-        *>, TwoTypeParameterSealedClassEnum> {
+        SealedEnumWithEnumProvider<TwoTypeParameterSealedClass<*, *>, TwoTypeParameterSealedClassEnum>,
+        EnumForSealedEnumProvider<TwoTypeParameterSealedClass<*, *>, TwoTypeParameterSealedClassEnum>
+        {
     public override val values: List<TwoTypeParameterSealedClass<*, *>> = listOf(
         TwoTypeParameterSealedClass.FirstObject,
         TwoTypeParameterSealedClass.SecondObject
@@ -262,8 +262,8 @@ public val TwoTypeParameterSealedClass.TwoType.sealedEnum: TwoTypeParameterSeale
  * If the given name doesn't correspond to any [TwoTypeParameterSealedClass], an
  * [IllegalArgumentException] will be thrown.
  */
-public fun TwoTypeParameterSealedClass.TwoType.valueOf(name: String): TwoTypeParameterSealedClass<*,
-        *> = TwoTypeParameterSealedClassSealedEnum.valueOf(name)
+public fun TwoTypeParameterSealedClass.TwoType.valueOf(name: String):
+        TwoTypeParameterSealedClass<*, *> = TwoTypeParameterSealedClassSealedEnum.valueOf(name)
 
 """.trimIndent()
 
@@ -315,10 +315,9 @@ public val LimitedTypeParameterSealedClassEnum.sealedObject: LimitedTypeParamete
  */
 public object LimitedTypeParameterSealedClassSealedEnum :
         SealedEnum<LimitedTypeParameterSealedClass<*, *>>,
-        SealedEnumWithEnumProvider<LimitedTypeParameterSealedClass<*, *>,
-        LimitedTypeParameterSealedClassEnum>,
-        EnumForSealedEnumProvider<LimitedTypeParameterSealedClass<*, *>,
-        LimitedTypeParameterSealedClassEnum> {
+        SealedEnumWithEnumProvider<LimitedTypeParameterSealedClass<*, *>, LimitedTypeParameterSealedClassEnum>,
+        EnumForSealedEnumProvider<LimitedTypeParameterSealedClass<*, *>, LimitedTypeParameterSealedClassEnum>
+        {
     public override val values: List<LimitedTypeParameterSealedClass<*, *>> = listOf(
         LimitedTypeParameterSealedClass.FirstObject,
         LimitedTypeParameterSealedClass.SecondObject

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithAbstractBaseClasses.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithAbstractBaseClasses.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnnecessaryAbstractClass")
+
 package com.livefront.sealedenum.compilation.generics
 
 import com.livefront.sealedenum.GenSealedEnum
@@ -35,7 +37,7 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [SealedEnumWithAbstractBaseClasses]
  */
 public enum class SealedEnumWithAbstractBaseClassesEnum(
-    sealedObject: SealedEnumWithAbstractBaseClasses
+    sealedObject: SealedEnumWithAbstractBaseClasses,
 ) : BaseClassInterface2<String> by sealedObject, BaseClassInterface1<BaseClassInterface1<Any?>> by
         sealedObject
 
@@ -56,10 +58,9 @@ public val SealedEnumWithAbstractBaseClassesEnum.sealedObject: SealedEnumWithAbs
  */
 public object SealedEnumWithAbstractBaseClassesSealedEnum :
         SealedEnum<SealedEnumWithAbstractBaseClasses>,
-        SealedEnumWithEnumProvider<SealedEnumWithAbstractBaseClasses,
-        SealedEnumWithAbstractBaseClassesEnum>,
-        EnumForSealedEnumProvider<SealedEnumWithAbstractBaseClasses,
-        SealedEnumWithAbstractBaseClassesEnum> {
+        SealedEnumWithEnumProvider<SealedEnumWithAbstractBaseClasses, SealedEnumWithAbstractBaseClassesEnum>,
+        EnumForSealedEnumProvider<SealedEnumWithAbstractBaseClasses, SealedEnumWithAbstractBaseClassesEnum>
+        {
     public override val values: List<SealedEnumWithAbstractBaseClasses> = emptyList()
 
 
@@ -148,7 +149,7 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [SealedEnumWithAbstractBaseClassesCovariantType]
  */
 public enum class SealedEnumWithAbstractBaseClassesCovariantTypeEnum(
-    sealedObject: SealedEnumWithAbstractBaseClassesCovariantType<*>
+    sealedObject: SealedEnumWithAbstractBaseClassesCovariantType<*>,
 ) : BaseClassInterface3<BaseClassInterface3<*>> by sealedObject
 
 /**
@@ -171,10 +172,9 @@ public val SealedEnumWithAbstractBaseClassesCovariantTypeEnum.sealedObject:
  */
 public object SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum :
         SealedEnum<SealedEnumWithAbstractBaseClassesCovariantType<*>>,
-        SealedEnumWithEnumProvider<SealedEnumWithAbstractBaseClassesCovariantType<*>,
-        SealedEnumWithAbstractBaseClassesCovariantTypeEnum>,
-        EnumForSealedEnumProvider<SealedEnumWithAbstractBaseClassesCovariantType<*>,
-        SealedEnumWithAbstractBaseClassesCovariantTypeEnum> {
+        SealedEnumWithEnumProvider<SealedEnumWithAbstractBaseClassesCovariantType<*>, SealedEnumWithAbstractBaseClassesCovariantTypeEnum>,
+        EnumForSealedEnumProvider<SealedEnumWithAbstractBaseClassesCovariantType<*>, SealedEnumWithAbstractBaseClassesCovariantTypeEnum>
+        {
     public override val values: List<SealedEnumWithAbstractBaseClassesCovariantType<*>> =
             emptyList()
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithInterfaces.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithInterfaces.kt
@@ -32,7 +32,7 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [EmptySealedClassWithInterface]
  */
 public enum class EmptySealedClassWithInterfaceEnum(
-    sealedObject: EmptySealedClassWithInterface
+    sealedObject: EmptySealedClassWithInterface,
 ) : TestInterface by sealedObject
 
 /**
@@ -51,9 +51,9 @@ public val EmptySealedClassWithInterfaceEnum.sealedObject: EmptySealedClassWithI
  * An implementation of [SealedEnum] for the sealed class [EmptySealedClassWithInterface]
  */
 public object EmptySealedClassWithInterfaceSealedEnum : SealedEnum<EmptySealedClassWithInterface>,
-        SealedEnumWithEnumProvider<EmptySealedClassWithInterface,
-        EmptySealedClassWithInterfaceEnum>, EnumForSealedEnumProvider<EmptySealedClassWithInterface,
-        EmptySealedClassWithInterfaceEnum> {
+        SealedEnumWithEnumProvider<EmptySealedClassWithInterface, EmptySealedClassWithInterfaceEnum>,
+        EnumForSealedEnumProvider<EmptySealedClassWithInterface, EmptySealedClassWithInterfaceEnum>
+        {
     public override val values: List<EmptySealedClassWithInterface> = emptyList()
 
 
@@ -137,7 +137,7 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [OneObjectSealedClassWithInterface]
  */
 public enum class OneObjectSealedClassWithInterfaceEnum(
-    sealedObject: OneObjectSealedClassWithInterface
+    sealedObject: OneObjectSealedClassWithInterface,
 ) : TestInterface by sealedObject {
     OneObjectSealedClassWithInterface_FirstObject(com.livefront.sealedenum.compilation.generics.OneObjectSealedClassWithInterface.FirstObject),
 }
@@ -159,10 +159,9 @@ public val OneObjectSealedClassWithInterfaceEnum.sealedObject: OneObjectSealedCl
  */
 public object OneObjectSealedClassWithInterfaceSealedEnum :
         SealedEnum<OneObjectSealedClassWithInterface>,
-        SealedEnumWithEnumProvider<OneObjectSealedClassWithInterface,
-        OneObjectSealedClassWithInterfaceEnum>,
-        EnumForSealedEnumProvider<OneObjectSealedClassWithInterface,
-        OneObjectSealedClassWithInterfaceEnum> {
+        SealedEnumWithEnumProvider<OneObjectSealedClassWithInterface, OneObjectSealedClassWithInterfaceEnum>,
+        EnumForSealedEnumProvider<OneObjectSealedClassWithInterface, OneObjectSealedClassWithInterfaceEnum>
+        {
     public override val values: List<OneObjectSealedClassWithInterface> = listOf(
         OneObjectSealedClassWithInterface.FirstObject
     )
@@ -262,7 +261,7 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [TwoObjectSealedClassWithGenericInterface]
  */
 public enum class TwoObjectSealedClassWithGenericInterfaceEnum(
-    sealedObject: TwoObjectSealedClassWithGenericInterface<TestInterface>
+    sealedObject: TwoObjectSealedClassWithGenericInterface<TestInterface>,
 ) : TestGenericInterface<TestInterface> by sealedObject {
     TwoObjectSealedClassWithGenericInterface_FirstObject(com.livefront.sealedenum.compilation.generics.TwoObjectSealedClassWithGenericInterface.FirstObject),
     TwoObjectSealedClassWithGenericInterface_SecondObject(com.livefront.sealedenum.compilation.generics.TwoObjectSealedClassWithGenericInterface.SecondObject),
@@ -287,10 +286,9 @@ public val TwoObjectSealedClassWithGenericInterfaceEnum.sealedObject:
  */
 public object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
         SealedEnum<TwoObjectSealedClassWithGenericInterface<TestInterface>>,
-        SealedEnumWithEnumProvider<TwoObjectSealedClassWithGenericInterface<TestInterface>,
-        TwoObjectSealedClassWithGenericInterfaceEnum>,
-        EnumForSealedEnumProvider<TwoObjectSealedClassWithGenericInterface<TestInterface>,
-        TwoObjectSealedClassWithGenericInterfaceEnum> {
+        SealedEnumWithEnumProvider<TwoObjectSealedClassWithGenericInterface<TestInterface>, TwoObjectSealedClassWithGenericInterfaceEnum>,
+        EnumForSealedEnumProvider<TwoObjectSealedClassWithGenericInterface<TestInterface>, TwoObjectSealedClassWithGenericInterfaceEnum>
+        {
     public override val values: List<TwoObjectSealedClassWithGenericInterface<TestInterface>> =
             listOf(
         TwoObjectSealedClassWithGenericInterface.FirstObject,
@@ -411,7 +409,7 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [SealedClassWithGetterInterface]
  */
 public enum class SealedClassWithGetterInterfaceEnum(
-    sealedObject: SealedClassWithGetterInterface
+    sealedObject: SealedClassWithGetterInterface,
 ) : TestGetterInterface by sealedObject {
     SealedClassWithGetterInterface_FirstObject(com.livefront.sealedenum.compilation.generics.SealedClassWithGetterInterface.FirstObject),
 }
@@ -432,10 +430,9 @@ public val SealedClassWithGetterInterfaceEnum.sealedObject: SealedClassWithGette
  * An implementation of [SealedEnum] for the sealed class [SealedClassWithGetterInterface]
  */
 public object SealedClassWithGetterInterfaceSealedEnum : SealedEnum<SealedClassWithGetterInterface>,
-        SealedEnumWithEnumProvider<SealedClassWithGetterInterface,
-        SealedClassWithGetterInterfaceEnum>,
-        EnumForSealedEnumProvider<SealedClassWithGetterInterface,
-        SealedClassWithGetterInterfaceEnum> {
+        SealedEnumWithEnumProvider<SealedClassWithGetterInterface, SealedClassWithGetterInterfaceEnum>,
+        EnumForSealedEnumProvider<SealedClassWithGetterInterface, SealedClassWithGetterInterfaceEnum>
+        {
     public override val values: List<SealedClassWithGetterInterface> = listOf(
         SealedClassWithGetterInterface.FirstObject
     )

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
@@ -229,25 +229,25 @@ public fun FirstClassHierarchy.A.B.Companion.valueOf(name: String): FirstClassHi
 
 class SecondClassHierarchy {
 
-    sealed class A {
+    sealed class Z {
 
-        object B : A()
+        object Y : Z()
 
-        sealed class C : A() {
+        sealed class X : Z() {
 
-            object D : C()
+            object W : X()
 
-            object E : C()
+            object V : X()
 
-            sealed class F : C() {
-                object G : F()
+            sealed class U : X() {
+                object T : U()
 
                 @GenSealedEnum
                 companion object
             }
 
-            sealed class H : C() {
-                object I : H()
+            sealed class S : X() {
+                object R : S()
 
                 @GenSealedEnum
                 companion object
@@ -257,15 +257,15 @@ class SecondClassHierarchy {
             companion object
         }
 
-        sealed class J : A() {
+        sealed class Q : Z() {
 
-            object K : J()
+            object P : Q()
 
             @GenSealedEnum
             companion object
         }
 
-        object L : A()
+        object O : Z()
 
         @GenSealedEnum
         companion object
@@ -273,7 +273,7 @@ class SecondClassHierarchy {
 }
 
 @Language("kotlin")
-val secondClassHierarchyAGenerated = """
+val secondClassHierarchyZGenerated = """
 package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
@@ -282,48 +282,48 @@ import kotlin.String
 import kotlin.collections.List
 
 /**
- * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A]
+ * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z]
  */
-public object SecondClassHierarchy_ASealedEnum : SealedEnum<SecondClassHierarchy.A> {
-    public override val values: List<SecondClassHierarchy.A> = listOf(
-        SecondClassHierarchy.A.B,
-        SecondClassHierarchy.A.C.D,
-        SecondClassHierarchy.A.C.E,
-        SecondClassHierarchy.A.C.F.G,
-        SecondClassHierarchy.A.C.H.I,
-        SecondClassHierarchy.A.J.K,
-        SecondClassHierarchy.A.L
+public object SecondClassHierarchy_ZSealedEnum : SealedEnum<SecondClassHierarchy.Z> {
+    public override val values: List<SecondClassHierarchy.Z> = listOf(
+        SecondClassHierarchy.Z.Y,
+        SecondClassHierarchy.Z.X.W,
+        SecondClassHierarchy.Z.X.V,
+        SecondClassHierarchy.Z.X.U.T,
+        SecondClassHierarchy.Z.X.S.R,
+        SecondClassHierarchy.Z.Q.P,
+        SecondClassHierarchy.Z.O
     )
 
 
-    public override fun ordinalOf(obj: SecondClassHierarchy.A): Int = when (obj) {
-        SecondClassHierarchy.A.B -> 0
-        SecondClassHierarchy.A.C.D -> 1
-        SecondClassHierarchy.A.C.E -> 2
-        SecondClassHierarchy.A.C.F.G -> 3
-        SecondClassHierarchy.A.C.H.I -> 4
-        SecondClassHierarchy.A.J.K -> 5
-        SecondClassHierarchy.A.L -> 6
+    public override fun ordinalOf(obj: SecondClassHierarchy.Z): Int = when (obj) {
+        SecondClassHierarchy.Z.Y -> 0
+        SecondClassHierarchy.Z.X.W -> 1
+        SecondClassHierarchy.Z.X.V -> 2
+        SecondClassHierarchy.Z.X.U.T -> 3
+        SecondClassHierarchy.Z.X.S.R -> 4
+        SecondClassHierarchy.Z.Q.P -> 5
+        SecondClassHierarchy.Z.O -> 6
     }
 
-    public override fun nameOf(obj: SecondClassHierarchy.A): String = when (obj) {
-        SecondClassHierarchy.A.B -> "SecondClassHierarchy_A_B"
-        SecondClassHierarchy.A.C.D -> "SecondClassHierarchy_A_C_D"
-        SecondClassHierarchy.A.C.E -> "SecondClassHierarchy_A_C_E"
-        SecondClassHierarchy.A.C.F.G -> "SecondClassHierarchy_A_C_F_G"
-        SecondClassHierarchy.A.C.H.I -> "SecondClassHierarchy_A_C_H_I"
-        SecondClassHierarchy.A.J.K -> "SecondClassHierarchy_A_J_K"
-        SecondClassHierarchy.A.L -> "SecondClassHierarchy_A_L"
+    public override fun nameOf(obj: SecondClassHierarchy.Z): String = when (obj) {
+        SecondClassHierarchy.Z.Y -> "SecondClassHierarchy_Z_Y"
+        SecondClassHierarchy.Z.X.W -> "SecondClassHierarchy_Z_X_W"
+        SecondClassHierarchy.Z.X.V -> "SecondClassHierarchy_Z_X_V"
+        SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
+        SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
+        SecondClassHierarchy.Z.Q.P -> "SecondClassHierarchy_Z_Q_P"
+        SecondClassHierarchy.Z.O -> "SecondClassHierarchy_Z_O"
     }
 
-    public override fun valueOf(name: String): SecondClassHierarchy.A = when (name) {
-        "SecondClassHierarchy_A_B" -> SecondClassHierarchy.A.B
-        "SecondClassHierarchy_A_C_D" -> SecondClassHierarchy.A.C.D
-        "SecondClassHierarchy_A_C_E" -> SecondClassHierarchy.A.C.E
-        "SecondClassHierarchy_A_C_F_G" -> SecondClassHierarchy.A.C.F.G
-        "SecondClassHierarchy_A_C_H_I" -> SecondClassHierarchy.A.C.H.I
-        "SecondClassHierarchy_A_J_K" -> SecondClassHierarchy.A.J.K
-        "SecondClassHierarchy_A_L" -> SecondClassHierarchy.A.L
+    public override fun valueOf(name: String): SecondClassHierarchy.Z = when (name) {
+        "SecondClassHierarchy_Z_Y" -> SecondClassHierarchy.Z.Y
+        "SecondClassHierarchy_Z_X_W" -> SecondClassHierarchy.Z.X.W
+        "SecondClassHierarchy_Z_X_V" -> SecondClassHierarchy.Z.X.V
+        "SecondClassHierarchy_Z_X_U_T" -> SecondClassHierarchy.Z.X.U.T
+        "SecondClassHierarchy_Z_X_S_R" -> SecondClassHierarchy.Z.X.S.R
+        "SecondClassHierarchy_Z_Q_P" -> SecondClassHierarchy.Z.Q.P
+        "SecondClassHierarchy_Z_O" -> SecondClassHierarchy.Z.O
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 }
@@ -331,40 +331,40 @@ public object SecondClassHierarchy_ASealedEnum : SealedEnum<SecondClassHierarchy
 /**
  * The index of [this] in the values list.
  */
-public val SecondClassHierarchy.A.ordinal: Int
-    get() = SecondClassHierarchy_ASealedEnum.ordinalOf(this)
+public val SecondClassHierarchy.Z.ordinal: Int
+    get() = SecondClassHierarchy_ZSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-public val SecondClassHierarchy.A.name: String
-    get() = SecondClassHierarchy_ASealedEnum.nameOf(this)
+public val SecondClassHierarchy.Z.name: String
+    get() = SecondClassHierarchy_ZSealedEnum.nameOf(this)
 
 /**
- * A list of all [SecondClassHierarchy.A] objects.
+ * A list of all [SecondClassHierarchy.Z] objects.
  */
-public val SecondClassHierarchy.A.Companion.values: List<SecondClassHierarchy.A>
-    get() = SecondClassHierarchy_ASealedEnum.values
+public val SecondClassHierarchy.Z.Companion.values: List<SecondClassHierarchy.Z>
+    get() = SecondClassHierarchy_ZSealedEnum.values
 
 /**
- * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A]
+ * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z]
  */
-public val SecondClassHierarchy.A.Companion.sealedEnum: SecondClassHierarchy_ASealedEnum
-    get() = SecondClassHierarchy_ASealedEnum
+public val SecondClassHierarchy.Z.Companion.sealedEnum: SecondClassHierarchy_ZSealedEnum
+    get() = SecondClassHierarchy_ZSealedEnum
 
 /**
- * Returns the [SecondClassHierarchy.A] object for the given [name].
+ * Returns the [SecondClassHierarchy.Z] object for the given [name].
  *
- * If the given name doesn't correspond to any [SecondClassHierarchy.A], an
+ * If the given name doesn't correspond to any [SecondClassHierarchy.Z], an
  * [IllegalArgumentException] will be thrown.
  */
-public fun SecondClassHierarchy.A.Companion.valueOf(name: String): SecondClassHierarchy.A =
-        SecondClassHierarchy_ASealedEnum.valueOf(name)
+public fun SecondClassHierarchy.Z.Companion.valueOf(name: String): SecondClassHierarchy.Z =
+        SecondClassHierarchy_ZSealedEnum.valueOf(name)
 
 """.trimIndent()
 
 @Language("kotlin")
-val secondClassHierarchyACGenerated = """
+val secondClassHierarchyZXGenerated = """
 package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
@@ -373,36 +373,36 @@ import kotlin.String
 import kotlin.collections.List
 
 /**
- * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A.C]
+ * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X]
  */
-public object SecondClassHierarchy_A_CSealedEnum : SealedEnum<SecondClassHierarchy.A.C> {
-    public override val values: List<SecondClassHierarchy.A.C> = listOf(
-        SecondClassHierarchy.A.C.D,
-        SecondClassHierarchy.A.C.E,
-        SecondClassHierarchy.A.C.F.G,
-        SecondClassHierarchy.A.C.H.I
+public object SecondClassHierarchy_Z_XSealedEnum : SealedEnum<SecondClassHierarchy.Z.X> {
+    public override val values: List<SecondClassHierarchy.Z.X> = listOf(
+        SecondClassHierarchy.Z.X.W,
+        SecondClassHierarchy.Z.X.V,
+        SecondClassHierarchy.Z.X.U.T,
+        SecondClassHierarchy.Z.X.S.R
     )
 
 
-    public override fun ordinalOf(obj: SecondClassHierarchy.A.C): Int = when (obj) {
-        SecondClassHierarchy.A.C.D -> 0
-        SecondClassHierarchy.A.C.E -> 1
-        SecondClassHierarchy.A.C.F.G -> 2
-        SecondClassHierarchy.A.C.H.I -> 3
+    public override fun ordinalOf(obj: SecondClassHierarchy.Z.X): Int = when (obj) {
+        SecondClassHierarchy.Z.X.W -> 0
+        SecondClassHierarchy.Z.X.V -> 1
+        SecondClassHierarchy.Z.X.U.T -> 2
+        SecondClassHierarchy.Z.X.S.R -> 3
     }
 
-    public override fun nameOf(obj: SecondClassHierarchy.A.C): String = when (obj) {
-        SecondClassHierarchy.A.C.D -> "SecondClassHierarchy_A_C_D"
-        SecondClassHierarchy.A.C.E -> "SecondClassHierarchy_A_C_E"
-        SecondClassHierarchy.A.C.F.G -> "SecondClassHierarchy_A_C_F_G"
-        SecondClassHierarchy.A.C.H.I -> "SecondClassHierarchy_A_C_H_I"
+    public override fun nameOf(obj: SecondClassHierarchy.Z.X): String = when (obj) {
+        SecondClassHierarchy.Z.X.W -> "SecondClassHierarchy_Z_X_W"
+        SecondClassHierarchy.Z.X.V -> "SecondClassHierarchy_Z_X_V"
+        SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
+        SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
     }
 
-    public override fun valueOf(name: String): SecondClassHierarchy.A.C = when (name) {
-        "SecondClassHierarchy_A_C_D" -> SecondClassHierarchy.A.C.D
-        "SecondClassHierarchy_A_C_E" -> SecondClassHierarchy.A.C.E
-        "SecondClassHierarchy_A_C_F_G" -> SecondClassHierarchy.A.C.F.G
-        "SecondClassHierarchy_A_C_H_I" -> SecondClassHierarchy.A.C.H.I
+    public override fun valueOf(name: String): SecondClassHierarchy.Z.X = when (name) {
+        "SecondClassHierarchy_Z_X_W" -> SecondClassHierarchy.Z.X.W
+        "SecondClassHierarchy_Z_X_V" -> SecondClassHierarchy.Z.X.V
+        "SecondClassHierarchy_Z_X_U_T" -> SecondClassHierarchy.Z.X.U.T
+        "SecondClassHierarchy_Z_X_S_R" -> SecondClassHierarchy.Z.X.S.R
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 }
@@ -410,40 +410,40 @@ public object SecondClassHierarchy_A_CSealedEnum : SealedEnum<SecondClassHierarc
 /**
  * The index of [this] in the values list.
  */
-public val SecondClassHierarchy.A.C.ordinal: Int
-    get() = SecondClassHierarchy_A_CSealedEnum.ordinalOf(this)
+public val SecondClassHierarchy.Z.X.ordinal: Int
+    get() = SecondClassHierarchy_Z_XSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-public val SecondClassHierarchy.A.C.name: String
-    get() = SecondClassHierarchy_A_CSealedEnum.nameOf(this)
+public val SecondClassHierarchy.Z.X.name: String
+    get() = SecondClassHierarchy_Z_XSealedEnum.nameOf(this)
 
 /**
- * A list of all [SecondClassHierarchy.A.C] objects.
+ * A list of all [SecondClassHierarchy.Z.X] objects.
  */
-public val SecondClassHierarchy.A.C.Companion.values: List<SecondClassHierarchy.A.C>
-    get() = SecondClassHierarchy_A_CSealedEnum.values
+public val SecondClassHierarchy.Z.X.Companion.values: List<SecondClassHierarchy.Z.X>
+    get() = SecondClassHierarchy_Z_XSealedEnum.values
 
 /**
- * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A.C]
+ * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X]
  */
-public val SecondClassHierarchy.A.C.Companion.sealedEnum: SecondClassHierarchy_A_CSealedEnum
-    get() = SecondClassHierarchy_A_CSealedEnum
+public val SecondClassHierarchy.Z.X.Companion.sealedEnum: SecondClassHierarchy_Z_XSealedEnum
+    get() = SecondClassHierarchy_Z_XSealedEnum
 
 /**
- * Returns the [SecondClassHierarchy.A.C] object for the given [name].
+ * Returns the [SecondClassHierarchy.Z.X] object for the given [name].
  *
- * If the given name doesn't correspond to any [SecondClassHierarchy.A.C], an
+ * If the given name doesn't correspond to any [SecondClassHierarchy.Z.X], an
  * [IllegalArgumentException] will be thrown.
  */
-public fun SecondClassHierarchy.A.C.Companion.valueOf(name: String): SecondClassHierarchy.A.C =
-        SecondClassHierarchy_A_CSealedEnum.valueOf(name)
+public fun SecondClassHierarchy.Z.X.Companion.valueOf(name: String): SecondClassHierarchy.Z.X =
+        SecondClassHierarchy_Z_XSealedEnum.valueOf(name)
 
 """.trimIndent()
 
 @Language("kotlin")
-val secondClassHierarchyACFGenerated = """
+val secondClassHierarchyZXUGenerated = """
 package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
@@ -452,24 +452,24 @@ import kotlin.String
 import kotlin.collections.List
 
 /**
- * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A.C.F]
+ * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X.U]
  */
-public object SecondClassHierarchy_A_C_FSealedEnum : SealedEnum<SecondClassHierarchy.A.C.F> {
-    public override val values: List<SecondClassHierarchy.A.C.F> = listOf(
-        SecondClassHierarchy.A.C.F.G
+public object SecondClassHierarchy_Z_X_USealedEnum : SealedEnum<SecondClassHierarchy.Z.X.U> {
+    public override val values: List<SecondClassHierarchy.Z.X.U> = listOf(
+        SecondClassHierarchy.Z.X.U.T
     )
 
 
-    public override fun ordinalOf(obj: SecondClassHierarchy.A.C.F): Int = when (obj) {
-        SecondClassHierarchy.A.C.F.G -> 0
+    public override fun ordinalOf(obj: SecondClassHierarchy.Z.X.U): Int = when (obj) {
+        SecondClassHierarchy.Z.X.U.T -> 0
     }
 
-    public override fun nameOf(obj: SecondClassHierarchy.A.C.F): String = when (obj) {
-        SecondClassHierarchy.A.C.F.G -> "SecondClassHierarchy_A_C_F_G"
+    public override fun nameOf(obj: SecondClassHierarchy.Z.X.U): String = when (obj) {
+        SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
     }
 
-    public override fun valueOf(name: String): SecondClassHierarchy.A.C.F = when (name) {
-        "SecondClassHierarchy_A_C_F_G" -> SecondClassHierarchy.A.C.F.G
+    public override fun valueOf(name: String): SecondClassHierarchy.Z.X.U = when (name) {
+        "SecondClassHierarchy_Z_X_U_T" -> SecondClassHierarchy.Z.X.U.T
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 }
@@ -477,40 +477,40 @@ public object SecondClassHierarchy_A_C_FSealedEnum : SealedEnum<SecondClassHiera
 /**
  * The index of [this] in the values list.
  */
-public val SecondClassHierarchy.A.C.F.ordinal: Int
-    get() = SecondClassHierarchy_A_C_FSealedEnum.ordinalOf(this)
+public val SecondClassHierarchy.Z.X.U.ordinal: Int
+    get() = SecondClassHierarchy_Z_X_USealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-public val SecondClassHierarchy.A.C.F.name: String
-    get() = SecondClassHierarchy_A_C_FSealedEnum.nameOf(this)
+public val SecondClassHierarchy.Z.X.U.name: String
+    get() = SecondClassHierarchy_Z_X_USealedEnum.nameOf(this)
 
 /**
- * A list of all [SecondClassHierarchy.A.C.F] objects.
+ * A list of all [SecondClassHierarchy.Z.X.U] objects.
  */
-public val SecondClassHierarchy.A.C.F.Companion.values: List<SecondClassHierarchy.A.C.F>
-    get() = SecondClassHierarchy_A_C_FSealedEnum.values
+public val SecondClassHierarchy.Z.X.U.Companion.values: List<SecondClassHierarchy.Z.X.U>
+    get() = SecondClassHierarchy_Z_X_USealedEnum.values
 
 /**
- * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A.C.F]
+ * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X.U]
  */
-public val SecondClassHierarchy.A.C.F.Companion.sealedEnum: SecondClassHierarchy_A_C_FSealedEnum
-    get() = SecondClassHierarchy_A_C_FSealedEnum
+public val SecondClassHierarchy.Z.X.U.Companion.sealedEnum: SecondClassHierarchy_Z_X_USealedEnum
+    get() = SecondClassHierarchy_Z_X_USealedEnum
 
 /**
- * Returns the [SecondClassHierarchy.A.C.F] object for the given [name].
+ * Returns the [SecondClassHierarchy.Z.X.U] object for the given [name].
  *
- * If the given name doesn't correspond to any [SecondClassHierarchy.A.C.F], an
+ * If the given name doesn't correspond to any [SecondClassHierarchy.Z.X.U], an
  * [IllegalArgumentException] will be thrown.
  */
-public fun SecondClassHierarchy.A.C.F.Companion.valueOf(name: String): SecondClassHierarchy.A.C.F =
-        SecondClassHierarchy_A_C_FSealedEnum.valueOf(name)
+public fun SecondClassHierarchy.Z.X.U.Companion.valueOf(name: String): SecondClassHierarchy.Z.X.U =
+        SecondClassHierarchy_Z_X_USealedEnum.valueOf(name)
 
 """.trimIndent()
 
 @Language("kotlin")
-val secondClassHierarchyACHGenerated = """
+val secondClassHierarchyZXSGenerated = """
 package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
@@ -519,24 +519,24 @@ import kotlin.String
 import kotlin.collections.List
 
 /**
- * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A.C.H]
+ * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X.S]
  */
-public object SecondClassHierarchy_A_C_HSealedEnum : SealedEnum<SecondClassHierarchy.A.C.H> {
-    public override val values: List<SecondClassHierarchy.A.C.H> = listOf(
-        SecondClassHierarchy.A.C.H.I
+public object SecondClassHierarchy_Z_X_SSealedEnum : SealedEnum<SecondClassHierarchy.Z.X.S> {
+    public override val values: List<SecondClassHierarchy.Z.X.S> = listOf(
+        SecondClassHierarchy.Z.X.S.R
     )
 
 
-    public override fun ordinalOf(obj: SecondClassHierarchy.A.C.H): Int = when (obj) {
-        SecondClassHierarchy.A.C.H.I -> 0
+    public override fun ordinalOf(obj: SecondClassHierarchy.Z.X.S): Int = when (obj) {
+        SecondClassHierarchy.Z.X.S.R -> 0
     }
 
-    public override fun nameOf(obj: SecondClassHierarchy.A.C.H): String = when (obj) {
-        SecondClassHierarchy.A.C.H.I -> "SecondClassHierarchy_A_C_H_I"
+    public override fun nameOf(obj: SecondClassHierarchy.Z.X.S): String = when (obj) {
+        SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
     }
 
-    public override fun valueOf(name: String): SecondClassHierarchy.A.C.H = when (name) {
-        "SecondClassHierarchy_A_C_H_I" -> SecondClassHierarchy.A.C.H.I
+    public override fun valueOf(name: String): SecondClassHierarchy.Z.X.S = when (name) {
+        "SecondClassHierarchy_Z_X_S_R" -> SecondClassHierarchy.Z.X.S.R
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 }
@@ -544,40 +544,40 @@ public object SecondClassHierarchy_A_C_HSealedEnum : SealedEnum<SecondClassHiera
 /**
  * The index of [this] in the values list.
  */
-public val SecondClassHierarchy.A.C.H.ordinal: Int
-    get() = SecondClassHierarchy_A_C_HSealedEnum.ordinalOf(this)
+public val SecondClassHierarchy.Z.X.S.ordinal: Int
+    get() = SecondClassHierarchy_Z_X_SSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-public val SecondClassHierarchy.A.C.H.name: String
-    get() = SecondClassHierarchy_A_C_HSealedEnum.nameOf(this)
+public val SecondClassHierarchy.Z.X.S.name: String
+    get() = SecondClassHierarchy_Z_X_SSealedEnum.nameOf(this)
 
 /**
- * A list of all [SecondClassHierarchy.A.C.H] objects.
+ * A list of all [SecondClassHierarchy.Z.X.S] objects.
  */
-public val SecondClassHierarchy.A.C.H.Companion.values: List<SecondClassHierarchy.A.C.H>
-    get() = SecondClassHierarchy_A_C_HSealedEnum.values
+public val SecondClassHierarchy.Z.X.S.Companion.values: List<SecondClassHierarchy.Z.X.S>
+    get() = SecondClassHierarchy_Z_X_SSealedEnum.values
 
 /**
- * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A.C.H]
+ * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X.S]
  */
-public val SecondClassHierarchy.A.C.H.Companion.sealedEnum: SecondClassHierarchy_A_C_HSealedEnum
-    get() = SecondClassHierarchy_A_C_HSealedEnum
+public val SecondClassHierarchy.Z.X.S.Companion.sealedEnum: SecondClassHierarchy_Z_X_SSealedEnum
+    get() = SecondClassHierarchy_Z_X_SSealedEnum
 
 /**
- * Returns the [SecondClassHierarchy.A.C.H] object for the given [name].
+ * Returns the [SecondClassHierarchy.Z.X.S] object for the given [name].
  *
- * If the given name doesn't correspond to any [SecondClassHierarchy.A.C.H], an
+ * If the given name doesn't correspond to any [SecondClassHierarchy.Z.X.S], an
  * [IllegalArgumentException] will be thrown.
  */
-public fun SecondClassHierarchy.A.C.H.Companion.valueOf(name: String): SecondClassHierarchy.A.C.H =
-        SecondClassHierarchy_A_C_HSealedEnum.valueOf(name)
+public fun SecondClassHierarchy.Z.X.S.Companion.valueOf(name: String): SecondClassHierarchy.Z.X.S =
+        SecondClassHierarchy_Z_X_SSealedEnum.valueOf(name)
 
 """.trimIndent()
 
 @Language("kotlin")
-val secondClassHierarchyAJGenerated = """
+val secondClassHierarchyZQGenerated = """
 package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
@@ -586,24 +586,24 @@ import kotlin.String
 import kotlin.collections.List
 
 /**
- * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A.J]
+ * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.Q]
  */
-public object SecondClassHierarchy_A_JSealedEnum : SealedEnum<SecondClassHierarchy.A.J> {
-    public override val values: List<SecondClassHierarchy.A.J> = listOf(
-        SecondClassHierarchy.A.J.K
+public object SecondClassHierarchy_Z_QSealedEnum : SealedEnum<SecondClassHierarchy.Z.Q> {
+    public override val values: List<SecondClassHierarchy.Z.Q> = listOf(
+        SecondClassHierarchy.Z.Q.P
     )
 
 
-    public override fun ordinalOf(obj: SecondClassHierarchy.A.J): Int = when (obj) {
-        SecondClassHierarchy.A.J.K -> 0
+    public override fun ordinalOf(obj: SecondClassHierarchy.Z.Q): Int = when (obj) {
+        SecondClassHierarchy.Z.Q.P -> 0
     }
 
-    public override fun nameOf(obj: SecondClassHierarchy.A.J): String = when (obj) {
-        SecondClassHierarchy.A.J.K -> "SecondClassHierarchy_A_J_K"
+    public override fun nameOf(obj: SecondClassHierarchy.Z.Q): String = when (obj) {
+        SecondClassHierarchy.Z.Q.P -> "SecondClassHierarchy_Z_Q_P"
     }
 
-    public override fun valueOf(name: String): SecondClassHierarchy.A.J = when (name) {
-        "SecondClassHierarchy_A_J_K" -> SecondClassHierarchy.A.J.K
+    public override fun valueOf(name: String): SecondClassHierarchy.Z.Q = when (name) {
+        "SecondClassHierarchy_Z_Q_P" -> SecondClassHierarchy.Z.Q.P
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 }
@@ -611,34 +611,34 @@ public object SecondClassHierarchy_A_JSealedEnum : SealedEnum<SecondClassHierarc
 /**
  * The index of [this] in the values list.
  */
-public val SecondClassHierarchy.A.J.ordinal: Int
-    get() = SecondClassHierarchy_A_JSealedEnum.ordinalOf(this)
+public val SecondClassHierarchy.Z.Q.ordinal: Int
+    get() = SecondClassHierarchy_Z_QSealedEnum.ordinalOf(this)
 
 /**
  * The name of [this] for use with valueOf.
  */
-public val SecondClassHierarchy.A.J.name: String
-    get() = SecondClassHierarchy_A_JSealedEnum.nameOf(this)
+public val SecondClassHierarchy.Z.Q.name: String
+    get() = SecondClassHierarchy_Z_QSealedEnum.nameOf(this)
 
 /**
- * A list of all [SecondClassHierarchy.A.J] objects.
+ * A list of all [SecondClassHierarchy.Z.Q] objects.
  */
-public val SecondClassHierarchy.A.J.Companion.values: List<SecondClassHierarchy.A.J>
-    get() = SecondClassHierarchy_A_JSealedEnum.values
+public val SecondClassHierarchy.Z.Q.Companion.values: List<SecondClassHierarchy.Z.Q>
+    get() = SecondClassHierarchy_Z_QSealedEnum.values
 
 /**
- * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.A.J]
+ * Returns an implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.Q]
  */
-public val SecondClassHierarchy.A.J.Companion.sealedEnum: SecondClassHierarchy_A_JSealedEnum
-    get() = SecondClassHierarchy_A_JSealedEnum
+public val SecondClassHierarchy.Z.Q.Companion.sealedEnum: SecondClassHierarchy_Z_QSealedEnum
+    get() = SecondClassHierarchy_Z_QSealedEnum
 
 /**
- * Returns the [SecondClassHierarchy.A.J] object for the given [name].
+ * Returns the [SecondClassHierarchy.Z.Q] object for the given [name].
  *
- * If the given name doesn't correspond to any [SecondClassHierarchy.A.J], an
+ * If the given name doesn't correspond to any [SecondClassHierarchy.Z.Q], an
  * [IllegalArgumentException] will be thrown.
  */
-public fun SecondClassHierarchy.A.J.Companion.valueOf(name: String): SecondClassHierarchy.A.J =
-        SecondClassHierarchy_A_JSealedEnum.valueOf(name)
+public fun SecondClassHierarchy.Z.Q.Companion.valueOf(name: String): SecondClassHierarchy.Z.Q =
+        SecondClassHierarchy_Z_QSealedEnum.valueOf(name)
 
 """.trimIndent()

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchyTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchyTests.kt
@@ -54,184 +54,184 @@ class SealedClassHierarchyTests {
     }
 
     @Test
-    fun `second hierarchy class A values`() {
+    fun `second hierarchy class Z values`() {
         assertEquals(
             listOf(
-                SecondClassHierarchy.A.B,
-                SecondClassHierarchy.A.C.D,
-                SecondClassHierarchy.A.C.E,
-                SecondClassHierarchy.A.C.F.G,
-                SecondClassHierarchy.A.C.H.I,
-                SecondClassHierarchy.A.J.K,
-                SecondClassHierarchy.A.L
+                SecondClassHierarchy.Z.Y,
+                SecondClassHierarchy.Z.X.W,
+                SecondClassHierarchy.Z.X.V,
+                SecondClassHierarchy.Z.X.U.T,
+                SecondClassHierarchy.Z.X.S.R,
+                SecondClassHierarchy.Z.Q.P,
+                SecondClassHierarchy.Z.O
             ),
-            SecondClassHierarchy.A.values
+            SecondClassHierarchy.Z.values
         )
     }
 
     @Test
-    fun `second hierarchy class A ordinal of A_B`() {
-        assertEquals(0, (SecondClassHierarchy.A.B as SecondClassHierarchy.A).ordinal)
+    fun `second hierarchy class Z ordinal of Z_Y`() {
+        assertEquals(0, (SecondClassHierarchy.Z.Y as SecondClassHierarchy.Z).ordinal)
     }
 
     @Test
-    fun `second hierarchy class A ordinal of A_C_D`() {
-        assertEquals(1, (SecondClassHierarchy.A.C.D as SecondClassHierarchy.A).ordinal)
+    fun `second hierarchy class Z ordinal of Z_X_W`() {
+        assertEquals(1, (SecondClassHierarchy.Z.X.W as SecondClassHierarchy.Z).ordinal)
     }
 
     @Test
-    fun `second hierarchy class A ordinal of A_C_E`() {
-        assertEquals(2, (SecondClassHierarchy.A.C.E as SecondClassHierarchy.A).ordinal)
+    fun `second hierarchy class Z ordinal of Z_X_V`() {
+        assertEquals(2, (SecondClassHierarchy.Z.X.V as SecondClassHierarchy.Z).ordinal)
     }
 
     @Test
-    fun `second hierarchy class A ordinal of A_C_F_G`() {
-        assertEquals(3, (SecondClassHierarchy.A.C.F.G as SecondClassHierarchy.A).ordinal)
+    fun `second hierarchy class Z ordinal of Z_X_U_T`() {
+        assertEquals(3, (SecondClassHierarchy.Z.X.U.T as SecondClassHierarchy.Z).ordinal)
     }
 
     @Test
-    fun `second hierarchy class A ordinal of A_C_H_I`() {
-        assertEquals(4, (SecondClassHierarchy.A.C.H.I as SecondClassHierarchy.A).ordinal)
+    fun `second hierarchy class Z ordinal of Z_X_S_R`() {
+        assertEquals(4, (SecondClassHierarchy.Z.X.S.R as SecondClassHierarchy.Z).ordinal)
     }
 
     @Test
-    fun `second hierarchy class A ordinal of A_J_K`() {
-        assertEquals(5, (SecondClassHierarchy.A.J.K as SecondClassHierarchy.A).ordinal)
+    fun `second hierarchy class Z ordinal of Z_Q_P`() {
+        assertEquals(5, (SecondClassHierarchy.Z.Q.P as SecondClassHierarchy.Z).ordinal)
     }
 
     @Test
-    fun `second hierarchy class A ordinal of A_L`() {
-        assertEquals(6, (SecondClassHierarchy.A.L as SecondClassHierarchy.A).ordinal)
+    fun `second hierarchy class Z ordinal of Z_O`() {
+        assertEquals(6, (SecondClassHierarchy.Z.O as SecondClassHierarchy.Z).ordinal)
     }
 
     @Test
-    fun `compilation for second hierarchy A generates correct code`() {
+    fun `compilation for second hierarchy Z generates correct code`() {
         val result = compile(getCommonSourceFile("compilation", "hierarchy", "SealedClassHierarchy.kt"))
 
         assertCompiles(result)
         assertGeneratedFileMatches(
-            "SecondClassHierarchy.A_SealedEnum.kt",
-            secondClassHierarchyAGenerated,
+            "SecondClassHierarchy.Z_SealedEnum.kt",
+            secondClassHierarchyZGenerated,
             result
         )
     }
 
     @Test
-    fun `second hierarchy class C values`() {
+    fun `second hierarchy class X values`() {
         assertEquals(
             listOf(
-                SecondClassHierarchy.A.C.D,
-                SecondClassHierarchy.A.C.E,
-                SecondClassHierarchy.A.C.F.G,
-                SecondClassHierarchy.A.C.H.I
+                SecondClassHierarchy.Z.X.W,
+                SecondClassHierarchy.Z.X.V,
+                SecondClassHierarchy.Z.X.U.T,
+                SecondClassHierarchy.Z.X.S.R
             ),
-            SecondClassHierarchy.A.C.values
+            SecondClassHierarchy.Z.X.values
         )
     }
 
     @Test
-    fun `second hierarchy class C ordinal of A_C_D`() {
-        assertEquals(0, (SecondClassHierarchy.A.C.D as SecondClassHierarchy.A.C).ordinal)
+    fun `second hierarchy class X ordinal of Z_X_W`() {
+        assertEquals(0, (SecondClassHierarchy.Z.X.W as SecondClassHierarchy.Z.X).ordinal)
     }
 
     @Test
-    fun `second hierarchy class C ordinal of A_C_E`() {
-        assertEquals(1, (SecondClassHierarchy.A.C.E as SecondClassHierarchy.A.C).ordinal)
+    fun `second hierarchy class X ordinal of Z_X_V`() {
+        assertEquals(1, (SecondClassHierarchy.Z.X.V as SecondClassHierarchy.Z.X).ordinal)
     }
 
     @Test
-    fun `second hierarchy class C ordinal of A_C_F_G`() {
-        assertEquals(2, (SecondClassHierarchy.A.C.F.G as SecondClassHierarchy.A.C).ordinal)
+    fun `second hierarchy class X ordinal of Z_X_U_T`() {
+        assertEquals(2, (SecondClassHierarchy.Z.X.U.T as SecondClassHierarchy.Z.X).ordinal)
     }
 
     @Test
-    fun `second hierarchy class C ordinal of A_C_H_I`() {
-        assertEquals(3, (SecondClassHierarchy.A.C.H.I as SecondClassHierarchy.A.C).ordinal)
+    fun `second hierarchy class X ordinal of Z_X_S_R`() {
+        assertEquals(3, (SecondClassHierarchy.Z.X.S.R as SecondClassHierarchy.Z.X).ordinal)
     }
 
     @Test
-    fun `compilation for second hierarchy C generates correct code`() {
+    fun `compilation for second hierarchy X generates correct code`() {
         val result = compile(getCommonSourceFile("compilation", "hierarchy", "SealedClassHierarchy.kt"))
 
         assertCompiles(result)
         assertGeneratedFileMatches(
-            "SecondClassHierarchy.A.C_SealedEnum.kt",
-            secondClassHierarchyACGenerated,
+            "SecondClassHierarchy.Z.X_SealedEnum.kt",
+            secondClassHierarchyZXGenerated,
             result
         )
     }
 
     @Test
-    fun `second hierarchy class F values`() {
+    fun `second hierarchy class U values`() {
         assertEquals(
-            listOf(SecondClassHierarchy.A.C.F.G),
-            SecondClassHierarchy.A.C.F.values
+            listOf(SecondClassHierarchy.Z.X.U.T),
+            SecondClassHierarchy.Z.X.U.values
         )
     }
 
     @Test
-    fun `second hierarchy class F ordinal of A_L`() {
-        assertEquals(0, (SecondClassHierarchy.A.C.F.G as SecondClassHierarchy.A.C.F).ordinal)
+    fun `second hierarchy class U ordinal of Z_X_U_T`() {
+        assertEquals(0, (SecondClassHierarchy.Z.X.U.T as SecondClassHierarchy.Z.X.U).ordinal)
     }
 
     @Test
-    fun `compilation for second hierarchy F generates correct code`() {
+    fun `compilation for second hierarchy U generates correct code`() {
         val result = compile(getCommonSourceFile("compilation", "hierarchy", "SealedClassHierarchy.kt"))
 
         assertCompiles(result)
         assertGeneratedFileMatches(
-            "SecondClassHierarchy.A.C.F_SealedEnum.kt",
-            secondClassHierarchyACFGenerated,
+            "SecondClassHierarchy.Z.X.U_SealedEnum.kt",
+            secondClassHierarchyZXUGenerated,
             result
         )
     }
 
     @Test
-    fun `second hierarchy class H values`() {
+    fun `second hierarchy class S values`() {
         assertEquals(
-            listOf(SecondClassHierarchy.A.C.H.I),
-            SecondClassHierarchy.A.C.H.values
+            listOf(SecondClassHierarchy.Z.X.S.R),
+            SecondClassHierarchy.Z.X.S.values
         )
     }
 
     @Test
-    fun `second hierarchy class H ordinal of A_C_H_I`() {
-        assertEquals(0, (SecondClassHierarchy.A.C.H.I as SecondClassHierarchy.A.C.H).ordinal)
+    fun `second hierarchy class S ordinal of Z_X_S_R`() {
+        assertEquals(0, (SecondClassHierarchy.Z.X.S.R as SecondClassHierarchy.Z.X.S).ordinal)
     }
 
     @Test
-    fun `compilation for second hierarchy H generates correct code`() {
+    fun `compilation for second hierarchy S generates correct code`() {
         val result = compile(getCommonSourceFile("compilation", "hierarchy", "SealedClassHierarchy.kt"))
 
         assertCompiles(result)
         assertGeneratedFileMatches(
-            "SecondClassHierarchy.A.C.H_SealedEnum.kt",
-            secondClassHierarchyACHGenerated,
+            "SecondClassHierarchy.Z.X.S_SealedEnum.kt",
+            secondClassHierarchyZXSGenerated,
             result
         )
     }
 
     @Test
-    fun `second hierarchy class J values`() {
+    fun `second hierarchy class Q values`() {
         assertEquals(
-            listOf(SecondClassHierarchy.A.J.K),
-            SecondClassHierarchy.A.J.values
+            listOf(SecondClassHierarchy.Z.Q.P),
+            SecondClassHierarchy.Z.Q.values
         )
     }
 
     @Test
-    fun `second hierarchy class J ordinal of A_J_K`() {
-        assertEquals(0, (SecondClassHierarchy.A.J.K as SecondClassHierarchy.A.J).ordinal)
+    fun `second hierarchy class Q ordinal of Z_Q_P`() {
+        assertEquals(0, (SecondClassHierarchy.Z.Q.P as SecondClassHierarchy.Z.Q).ordinal)
     }
 
     @Test
-    fun `compilation for second hierarchy J generates correct code`() {
+    fun `compilation for second hierarchy Q generates correct code`() {
         val result = compile(getCommonSourceFile("compilation", "hierarchy", "SealedClassHierarchy.kt"))
 
         assertCompiles(result)
         assertGeneratedFileMatches(
-            "SecondClassHierarchy.A.J_SealedEnum.kt",
-            secondClassHierarchyAJGenerated,
+            "SecondClassHierarchy.Z.Q_SealedEnum.kt",
+            secondClassHierarchyZQGenerated,
             result
         )
     }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
@@ -123,6 +123,10 @@ object BetaFirstObject : BetaOutsideSealedClass()
 
 object BetaSecondObject : BetaOutsideSealedClass()
 
+object BetaThirdObject : BetaOutsideSealedClass()
+
+object BetaFourthObject : BetaOutsideSealedClass()
+
 @Language("kotlin")
 val betaOutsideSealedClassGenerated = """
 package com.livefront.sealedenum.compilation.location
@@ -140,7 +144,9 @@ import kotlin.collections.List
  */
 public enum class BetaOutsideSealedClassEnum() {
     BetaFirstObject,
+    BetaFourthObject,
     BetaSecondObject,
+    BetaThirdObject,
 }
 
 /**
@@ -163,7 +169,9 @@ public object BetaOutsideSealedClassSealedEnum : SealedEnum<BetaOutsideSealedCla
         EnumForSealedEnumProvider<BetaOutsideSealedClass, BetaOutsideSealedClassEnum> {
     public override val values: List<BetaOutsideSealedClass> = listOf(
         BetaFirstObject,
-        BetaSecondObject
+        BetaFourthObject,
+        BetaSecondObject,
+        BetaThirdObject
     )
 
 
@@ -172,30 +180,40 @@ public object BetaOutsideSealedClassSealedEnum : SealedEnum<BetaOutsideSealedCla
 
     public override fun ordinalOf(obj: BetaOutsideSealedClass): Int = when (obj) {
         BetaFirstObject -> 0
-        BetaSecondObject -> 1
+        BetaFourthObject -> 1
+        BetaSecondObject -> 2
+        BetaThirdObject -> 3
     }
 
     public override fun nameOf(obj: BetaOutsideSealedClass): String = when (obj) {
         BetaFirstObject -> "BetaFirstObject"
+        BetaFourthObject -> "BetaFourthObject"
         BetaSecondObject -> "BetaSecondObject"
+        BetaThirdObject -> "BetaThirdObject"
     }
 
     public override fun valueOf(name: String): BetaOutsideSealedClass = when (name) {
         "BetaFirstObject" -> BetaFirstObject
+        "BetaFourthObject" -> BetaFourthObject
         "BetaSecondObject" -> BetaSecondObject
+        "BetaThirdObject" -> BetaThirdObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
     public override fun sealedObjectToEnum(obj: BetaOutsideSealedClass): BetaOutsideSealedClassEnum
             = when (obj) {
         BetaFirstObject -> BetaOutsideSealedClassEnum.BetaFirstObject
+        BetaFourthObject -> BetaOutsideSealedClassEnum.BetaFourthObject
         BetaSecondObject -> BetaOutsideSealedClassEnum.BetaSecondObject
+        BetaThirdObject -> BetaOutsideSealedClassEnum.BetaThirdObject
     }
 
     public override fun enumToSealedObject(`enum`: BetaOutsideSealedClassEnum):
             BetaOutsideSealedClass = when (enum) {
         BetaOutsideSealedClassEnum.BetaFirstObject -> BetaFirstObject
+        BetaOutsideSealedClassEnum.BetaFourthObject -> BetaFourthObject
         BetaOutsideSealedClassEnum.BetaSecondObject -> BetaSecondObject
+        BetaOutsideSealedClassEnum.BetaThirdObject -> BetaThirdObject
     }
 }
 
@@ -246,6 +264,8 @@ sealed class GammaOutsideSealedClass {
 
 object GammaThirdObject : GammaOutsideSealedClass()
 
+object GammaFourthObject : GammaOutsideSealedClass()
+
 @Language("kotlin")
 val gammaOutsideSealedClassGenerated = """
 package com.livefront.sealedenum.compilation.location
@@ -262,8 +282,9 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [GammaOutsideSealedClass]
  */
 public enum class GammaOutsideSealedClassEnum() {
-    GammaFirstObject,
     GammaOutsideSealedClass_GammaSecondObject,
+    GammaFirstObject,
+    GammaFourthObject,
     GammaThirdObject,
 }
 
@@ -286,8 +307,9 @@ public object GammaOutsideSealedClassSealedEnum : SealedEnum<GammaOutsideSealedC
         SealedEnumWithEnumProvider<GammaOutsideSealedClass, GammaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<GammaOutsideSealedClass, GammaOutsideSealedClassEnum> {
     public override val values: List<GammaOutsideSealedClass> = listOf(
-        GammaFirstObject,
         GammaOutsideSealedClass.GammaSecondObject,
+        GammaFirstObject,
+        GammaFourthObject,
         GammaThirdObject
     )
 
@@ -296,37 +318,42 @@ public object GammaOutsideSealedClassSealedEnum : SealedEnum<GammaOutsideSealedC
         get() = GammaOutsideSealedClassEnum::class.java
 
     public override fun ordinalOf(obj: GammaOutsideSealedClass): Int = when (obj) {
-        GammaFirstObject -> 0
-        GammaOutsideSealedClass.GammaSecondObject -> 1
-        GammaThirdObject -> 2
+        GammaOutsideSealedClass.GammaSecondObject -> 0
+        GammaFirstObject -> 1
+        GammaFourthObject -> 2
+        GammaThirdObject -> 3
     }
 
     public override fun nameOf(obj: GammaOutsideSealedClass): String = when (obj) {
-        GammaFirstObject -> "GammaFirstObject"
         GammaOutsideSealedClass.GammaSecondObject -> "GammaOutsideSealedClass_GammaSecondObject"
+        GammaFirstObject -> "GammaFirstObject"
+        GammaFourthObject -> "GammaFourthObject"
         GammaThirdObject -> "GammaThirdObject"
     }
 
     public override fun valueOf(name: String): GammaOutsideSealedClass = when (name) {
-        "GammaFirstObject" -> GammaFirstObject
         "GammaOutsideSealedClass_GammaSecondObject" -> GammaOutsideSealedClass.GammaSecondObject
+        "GammaFirstObject" -> GammaFirstObject
+        "GammaFourthObject" -> GammaFourthObject
         "GammaThirdObject" -> GammaThirdObject
         else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
     }
 
     public override fun sealedObjectToEnum(obj: GammaOutsideSealedClass):
             GammaOutsideSealedClassEnum = when (obj) {
-        GammaFirstObject -> GammaOutsideSealedClassEnum.GammaFirstObject
         GammaOutsideSealedClass.GammaSecondObject ->
                 GammaOutsideSealedClassEnum.GammaOutsideSealedClass_GammaSecondObject
+        GammaFirstObject -> GammaOutsideSealedClassEnum.GammaFirstObject
+        GammaFourthObject -> GammaOutsideSealedClassEnum.GammaFourthObject
         GammaThirdObject -> GammaOutsideSealedClassEnum.GammaThirdObject
     }
 
     public override fun enumToSealedObject(`enum`: GammaOutsideSealedClassEnum):
             GammaOutsideSealedClass = when (enum) {
-        GammaOutsideSealedClassEnum.GammaFirstObject -> GammaFirstObject
         GammaOutsideSealedClassEnum.GammaOutsideSealedClass_GammaSecondObject ->
                 GammaOutsideSealedClass.GammaSecondObject
+        GammaOutsideSealedClassEnum.GammaFirstObject -> GammaFirstObject
+        GammaOutsideSealedClassEnum.GammaFourthObject -> GammaFourthObject
         GammaOutsideSealedClassEnum.GammaThirdObject -> GammaThirdObject
     }
 }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClassTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClassTests.kt
@@ -40,7 +40,15 @@ class OutsideSealedClassTests {
 
     @Test
     fun `two objects outside sealed class`() {
-        assertEquals(listOf(BetaFirstObject, BetaSecondObject), BetaOutsideSealedClass.values)
+        assertEquals(
+            listOf(
+                BetaFirstObject,
+                BetaFourthObject,
+                BetaSecondObject,
+                BetaThirdObject,
+            ),
+            BetaOutsideSealedClass.values
+        )
     }
 
     @Test
@@ -48,7 +56,9 @@ class OutsideSealedClassTests {
         assertEquals(
             listOf(
                 BetaOutsideSealedClassEnum.BetaFirstObject,
-                BetaOutsideSealedClassEnum.BetaSecondObject
+                BetaOutsideSealedClassEnum.BetaFourthObject,
+                BetaOutsideSealedClassEnum.BetaSecondObject,
+                BetaOutsideSealedClassEnum.BetaThirdObject,
             ),
             enumValues<BetaOutsideSealedClassEnum>().toList()
         )
@@ -73,7 +83,12 @@ class OutsideSealedClassTests {
     @Test
     fun `outside object ordering`() {
         assertEquals(
-            listOf(GammaFirstObject, GammaOutsideSealedClass.GammaSecondObject, GammaThirdObject),
+            listOf(
+                GammaOutsideSealedClass.GammaSecondObject,
+                GammaFirstObject,
+                GammaFourthObject,
+                GammaThirdObject,
+            ),
             GammaOutsideSealedClass.values
         )
     }
@@ -82,8 +97,9 @@ class OutsideSealedClassTests {
     fun `outside enum ordering`() {
         assertEquals(
             listOf(
-                GammaOutsideSealedClassEnum.GammaFirstObject,
                 GammaOutsideSealedClassEnum.GammaOutsideSealedClass_GammaSecondObject,
+                GammaOutsideSealedClassEnum.GammaFirstObject,
+                GammaOutsideSealedClassEnum.GammaFourthObject,
                 GammaOutsideSealedClassEnum.GammaThirdObject,
             ),
             enumValues<GammaOutsideSealedClassEnum>().toList()

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
@@ -108,8 +108,9 @@ public val TreeLevelOrderEnum.sealedObject: Tree
 /**
  * An implementation of [SealedEnum] for the sealed class [Tree]
  */
-public object TreeLevelOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
-        TreeLevelOrderEnum>, EnumForSealedEnumProvider<Tree, TreeLevelOrderEnum> {
+public object TreeLevelOrderSealedEnum : SealedEnum<Tree>,
+        SealedEnumWithEnumProvider<Tree, TreeLevelOrderEnum>,
+        EnumForSealedEnumProvider<Tree, TreeLevelOrderEnum> {
     public override val values: List<Tree> = listOf(
         Tree.A,
         Tree.K,
@@ -285,8 +286,9 @@ public val TreePostOrderEnum.sealedObject: Tree
 /**
  * An implementation of [SealedEnum] for the sealed class [Tree]
  */
-public object TreePostOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
-        TreePostOrderEnum>, EnumForSealedEnumProvider<Tree, TreePostOrderEnum> {
+public object TreePostOrderSealedEnum : SealedEnum<Tree>,
+        SealedEnumWithEnumProvider<Tree, TreePostOrderEnum>,
+        EnumForSealedEnumProvider<Tree, TreePostOrderEnum> {
     public override val values: List<Tree> = listOf(
         Tree.B.C.F.G,
         Tree.B.C.F.H,
@@ -462,8 +464,9 @@ public val TreeInOrderEnum.sealedObject: Tree
 /**
  * An implementation of [SealedEnum] for the sealed class [Tree]
  */
-public object TreeInOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
-        TreeInOrderEnum>, EnumForSealedEnumProvider<Tree, TreeInOrderEnum> {
+public object TreeInOrderSealedEnum : SealedEnum<Tree>,
+        SealedEnumWithEnumProvider<Tree, TreeInOrderEnum>,
+        EnumForSealedEnumProvider<Tree, TreeInOrderEnum> {
     public override val values: List<Tree> = listOf(
         Tree.A,
         Tree.B.C.D,
@@ -638,8 +641,9 @@ public val TreePreOrderEnum.sealedObject: Tree
 /**
  * An implementation of [SealedEnum] for the sealed class [Tree]
  */
-public object TreePreOrderSealedEnum : SealedEnum<Tree>, SealedEnumWithEnumProvider<Tree,
-        TreePreOrderEnum>, EnumForSealedEnumProvider<Tree, TreePreOrderEnum> {
+public object TreePreOrderSealedEnum : SealedEnum<Tree>,
+        SealedEnumWithEnumProvider<Tree, TreePreOrderEnum>,
+        EnumForSealedEnumProvider<Tree, TreePreOrderEnum> {
     public override val values: List<Tree> = listOf(
         Tree.A,
         Tree.K,

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnum.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnum.kt
@@ -51,7 +51,7 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [Environments]
  */
 public enum class EnvironmentsEnum(
-    sealedObject: Environments
+    sealedObject: Environments,
 ) : Uri by sealedObject {
     Environments_Http_Livefront(com.livefront.sealedenum.compilation.usecases.Environments.Http.Livefront),
     Environments_Http_Google(com.livefront.sealedenum.compilation.usecases.Environments.Http.Google),

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClass.kt
@@ -38,7 +38,7 @@ import kotlin.collections.List
  * [ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass]
  */
 public enum class ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum(
-    sealedObject: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass
+    sealedObject: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass,
 ) : JavaProtectedInterfaceBaseClass.ProtectedInterface by sealedObject {
     ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_FirstObject(com.livefront.sealedenum.compilation.visibility.ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject),
     ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_SecondObject(com.livefront.sealedenum.compilation.visibility.ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject),
@@ -66,10 +66,9 @@ public val ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum.sealed
  */
 public object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEnum :
         SealedEnum<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass>,
-        SealedEnumWithEnumProvider<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass,
-        ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>,
-        EnumForSealedEnumProvider<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass,
-        ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum> {
+        SealedEnumWithEnumProvider<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass, ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>,
+        EnumForSealedEnumProvider<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass, ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>
+        {
     public override val values: List<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass> =
             listOf(
         ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject,

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClass.kt
@@ -75,10 +75,8 @@ public object
         ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassSealedEnum
         :
         SealedEnum<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass>,
-        SealedEnumWithEnumProvider<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass,
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum>,
-        EnumForSealedEnumProvider<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass,
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum>
+        SealedEnumWithEnumProvider<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass, ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum>,
+        EnumForSealedEnumProvider<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass, ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum>
         {
     public override val values:
             List<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass>

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
@@ -434,10 +434,9 @@ internal val InternalSealedAndCompanionSealedClassEnum.sealedObject:
  */
 internal object InternalSealedAndCompanionSealedClassSealedEnum :
         SealedEnum<InternalSealedAndCompanionSealedClass>,
-        SealedEnumWithEnumProvider<InternalSealedAndCompanionSealedClass,
-        InternalSealedAndCompanionSealedClassEnum>,
-        EnumForSealedEnumProvider<InternalSealedAndCompanionSealedClass,
-        InternalSealedAndCompanionSealedClassEnum> {
+        SealedEnumWithEnumProvider<InternalSealedAndCompanionSealedClass, InternalSealedAndCompanionSealedClassEnum>,
+        EnumForSealedEnumProvider<InternalSealedAndCompanionSealedClass, InternalSealedAndCompanionSealedClassEnum>
+        {
     public override val values: List<InternalSealedAndCompanionSealedClass> = listOf(
         InternalSealedAndCompanionSealedClass.FirstObject,
         InternalSealedAndCompanionSealedClass.SecondObject

--- a/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameName.kt
+++ b/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameName.kt
@@ -50,10 +50,9 @@ public val NestedObjectsWithSameName_Companion_EmptySealedClassEnum.sealedObject
  */
 public object NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum :
         SealedEnum<NestedObjectsWithSameName.Companion.EmptySealedClass>,
-        SealedEnumWithEnumProvider<NestedObjectsWithSameName.Companion.EmptySealedClass,
-        NestedObjectsWithSameName_Companion_EmptySealedClassEnum>,
-        EnumForSealedEnumProvider<NestedObjectsWithSameName.Companion.EmptySealedClass,
-        NestedObjectsWithSameName_Companion_EmptySealedClassEnum> {
+        SealedEnumWithEnumProvider<NestedObjectsWithSameName.Companion.EmptySealedClass, NestedObjectsWithSameName_Companion_EmptySealedClassEnum>,
+        EnumForSealedEnumProvider<NestedObjectsWithSameName.Companion.EmptySealedClass, NestedObjectsWithSameName_Companion_EmptySealedClassEnum>
+        {
     public override val values: List<NestedObjectsWithSameName.Companion.EmptySealedClass> =
             emptyList()
 

--- a/processing-tests/processor-tests/src/test/kotlin/com/livefront/sealedenum/compilation/kitchensink/JavaBaseClasses.kt
+++ b/processing-tests/processor-tests/src/test/kotlin/com/livefront/sealedenum/compilation/kitchensink/JavaBaseClasses.kt
@@ -55,7 +55,7 @@ import kotlin.collections.List
  * An isomorphic enum for the sealed class [JavaBaseClassesSealedClass]
  */
 public enum class JavaBaseClassesSealedClassEnum(
-    sealedObject: JavaBaseClassesSealedClass<*>
+    sealedObject: JavaBaseClassesSealedClass<*>,
 ) : KotlinInterface5<KotlinInterface1> by sealedObject, JavaInterface3<Int> by sealedObject,
         KotlinInterface4<Double> by sealedObject, KotlinInterface6<Int> by sealedObject,
         JavaInterface2<List<String>> by sealedObject,

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -21,5 +21,5 @@ kapt {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions.freeCompilerArgs += "-Xopt-in=com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview"
+    kotlinOptions.freeCompilerArgs += "-opt-in=com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview"
 }


### PR DESCRIPTION
This updates to Kotlin 1.6.21 (requiring just minor changes) and then to 1.7.0.

The update to 1.7.0 is more problematic, due to #106 . As a result, this PR more strictly defines the ordering of sealed subclasses, primarily to ensure the main use case is preserved (where ordering remains fixed for sealed subclasses declared inside of the sealed class). This new specified order is also documented on the README.