### PR TITLE
Prepare 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.5.0
+## Features:
+- Update to Kotlin 1.7
+
+## Breaking changes:
+- The implicit order of sealed subclasses was changed in Kotlin 1.7, resulting in different ordinal orders when using `sealed-enum` `0.4.0` and below.
+  `sealed-enum` `0.5.0` restored the expected behavior when declaring subclasses as nested inner classes and defined a deterministic order when subclasses occur elsewhere in the file and package. 
+
+## Miscellaneous updates:
+- Various dependency updates
+- Switch to using version catalogs and convention plugins
+
 # 0.4.0
 ## Features:
 - Added full support for `sealed interface`s

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.parallel=true
 kotlin.code.style=official
 
 group=com.livefront.sealedenum
-version=0.4.0
+version=0.5.0


### PR DESCRIPTION
Prepares for a `0.5.0` release. This mainly fixes behavior on Kotlin 1.7, and other various dependencies updates.