### PR TITLE
Simplify Gradle caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,8 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Cache Gradle Files
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: v1-${{ runner.os }}-gradle-${{ matrix.java-version }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
-          restore-keys: |
-            v1-${{ runner.os }}-gradle-${{ matrix.java-version }}-
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: Configure Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,13 +21,8 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Cache Gradle Files
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: v1-${{ runner.os }}-gradle-${{ matrix.java-version }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
-          restore-keys: |
-            v1-${{ runner.os }}-gradle-${{ matrix.java-version }}-
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: Configure JDK
         uses: actions/setup-java@v1


### PR DESCRIPTION
Simplifies the Gradle caching setup by using https://github.com/gradle/gradle-build-action, which automatically handles caching  and invalidating different portions of Gradle correctly.