### PR TITLE
Add clear caches workflow

### DIFF
--- a/.github/workflows/clear-caches.yml
+++ b/.github/workflows/clear-caches.yml
@@ -1,0 +1,29 @@
+name: clear-caches
+
+on: workflow_dispatch
+
+jobs:
+  clear:
+    name: Clear all caches
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          # Keep track of the total number of caches deleted
+          TOTAL_COUNT=0
+          # The cache list is paginated, so we won't necessarily get all ids with the first call
+          while true; do
+            LIST_CACHES=$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/actions/caches)
+            REMAINING_COUNT=$(echo $LIST_CACHES | jq .total_count)
+            # If there are no more, we're done!
+            [[ $REMAINING_COUNT > 0 ]] || break
+            # Parse out the list of ids
+            IDS=$(echo $LIST_CACHES | jq .actions_caches[].id)
+            for ID in ${IDS[@]}; do
+              echo "Clearing $ID"
+              gh api --method DELETE -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/actions/caches/$ID
+              TOTAL_COUNT=$((TOTAL_COUNT + 1))
+            done
+          done
+          echo "Cleared $TOTAL_COUNT caches"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub recently exposed an API to list and delete cache entries from GitHub Actions: https://github.blog/changelog/2022-06-27-list-and-delete-caches-in-your-actions-workflows/

There isn't an easy UI affordance for this yet, so this PR adds a small utility workflow that can be triggered manually that queries the API, and loops through all of the ids to clear out all caches.

This shouldn't usually be necessary, but is a bit nicer that doing the process manually if something goes wrong.