### PR TITLE
Update JDK test versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,7 @@ jobs:
       matrix:
         java-version:
           - 1.8
-          - 9
-          - 10
           - 11
-          - 12
-          - 13
-          - 14
-          - 15
-          - 16
           - 17
         os:
           - ubuntu-latest


### PR DESCRIPTION
Restricts to testing on 1.8, 11 and 17 as the LTS versions, 10 in particular seems to be broken.