### PR TITLE
Convert Class to KClass

### DIFF
--- a/processing-common/src/main/kotlin/com/livefront/sealedenum/internal/common/spec/SealedEnumTypeSpec.kt
+++ b/processing-common/src/main/kotlin/com/livefront/sealedenum/internal/common/spec/SealedEnumTypeSpec.kt
@@ -14,6 +14,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.buildCodeBlock
 import javax.lang.model.element.TypeElement
+import kotlin.reflect.KClass
 
 /**
  * A builder for a [SealedEnum] object for the given [sealedClass].
@@ -212,13 +213,13 @@ internal data class SealedEnumTypeSpec(
             .build()
 
     private fun createEnumClassGetter(enumForSealedEnum: ClassName): PropertySpec {
-        val parameterizedClass = Class::class.asClassName().parameterizedBy(enumForSealedEnum)
+        val parameterizedClass = KClass::class.asClassName().parameterizedBy(enumForSealedEnum)
 
         return PropertySpec.builder("enumClass", parameterizedClass)
             .addModifiers(KModifier.OVERRIDE)
             .getter(
                 FunSpec.getterBuilder()
-                    .addStatement("return %T::class.java", enumForSealedEnum)
+                    .addStatement("return %T::class", enumForSealedEnum)
                     .build()
             )
             .build()

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClass.kt
@@ -15,10 +15,10 @@ package com.livefront.sealedenum.compilation.basic
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [EmptySealedClass]
@@ -46,8 +46,8 @@ public object EmptySealedClassSealedEnum : SealedEnum<EmptySealedClass>,
     public override val values: List<EmptySealedClass> = emptyList()
 
 
-    public override val enumClass: Class<EmptySealedClassEnum>
-        get() = EmptySealedClassEnum::class.java
+    public override val enumClass: KClass<EmptySealedClassEnum>
+        get() = EmptySealedClassEnum::class
 
     public override fun ordinalOf(obj: EmptySealedClass): Int = throw
             AssertionError("Constructing a EmptySealedClass is impossible, since it has no sealed subclasses")

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClassTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClassTests.kt
@@ -23,7 +23,7 @@ class EmptySealedClassTests {
 
     @Test
     fun `correct enum class`() {
-        assertEquals(EmptySealedClassEnum::class.java, EmptySealedClass.sealedEnum.enumClass)
+        assertEquals(EmptySealedClassEnum::class, EmptySealedClass.sealedEnum.enumClass)
     }
 
     @Test

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedInterface.kt
@@ -15,10 +15,10 @@ package com.livefront.sealedenum.compilation.basic
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [EmptySealedInterface]
@@ -46,8 +46,8 @@ public object EmptySealedInterfaceSealedEnum : SealedEnum<EmptySealedInterface>,
     public override val values: List<EmptySealedInterface> = emptyList()
 
 
-    public override val enumClass: Class<EmptySealedInterfaceEnum>
-        get() = EmptySealedInterfaceEnum::class.java
+    public override val enumClass: KClass<EmptySealedInterfaceEnum>
+        get() = EmptySealedInterfaceEnum::class
 
     public override fun ordinalOf(obj: EmptySealedInterface): Int = throw
             AssertionError("Constructing a EmptySealedInterface is impossible, since it has no sealed subclasses")

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedInterfaceTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedInterfaceTests.kt
@@ -23,7 +23,7 @@ class EmptySealedInterfaceTests {
 
     @Test
     fun `correct enum class`() {
-        assertEquals(EmptySealedInterfaceEnum::class.java, EmptySealedInterface.sealedEnum.enumClass)
+        assertEquals(EmptySealedInterfaceEnum::class, EmptySealedInterface.sealedEnum.enumClass)
     }
 
     @Test

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClass.kt
@@ -17,10 +17,10 @@ package com.livefront.sealedenum.compilation.basic
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [OneObjectSealedClass]
@@ -52,8 +52,8 @@ public object OneObjectSealedClassSealedEnum : SealedEnum<OneObjectSealedClass>,
     )
 
 
-    public override val enumClass: Class<OneObjectSealedClassEnum>
-        get() = OneObjectSealedClassEnum::class.java
+    public override val enumClass: KClass<OneObjectSealedClassEnum>
+        get() = OneObjectSealedClassEnum::class
 
     public override fun ordinalOf(obj: OneObjectSealedClass): Int = when (obj) {
         OneObjectSealedClass.FirstObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClassTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClassTests.kt
@@ -31,7 +31,7 @@ class OneObjectSealedClassTests {
 
     @Test
     fun `correct enum class`() {
-        assertEquals(OneObjectSealedClassEnum::class.java, OneObjectSealedClass.sealedEnum.enumClass)
+        assertEquals(OneObjectSealedClassEnum::class, OneObjectSealedClass.sealedEnum.enumClass)
     }
 
     @Test

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedInterface.kt
@@ -17,10 +17,10 @@ package com.livefront.sealedenum.compilation.basic
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [OneObjectSealedInterface]
@@ -52,8 +52,8 @@ public object OneObjectSealedInterfaceSealedEnum : SealedEnum<OneObjectSealedInt
     )
 
 
-    public override val enumClass: Class<OneObjectSealedInterfaceEnum>
-        get() = OneObjectSealedInterfaceEnum::class.java
+    public override val enumClass: KClass<OneObjectSealedInterfaceEnum>
+        get() = OneObjectSealedInterfaceEnum::class
 
     public override fun ordinalOf(obj: OneObjectSealedInterface): Int = when (obj) {
         OneObjectSealedInterface.FirstObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedInterfaceTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedInterfaceTests.kt
@@ -31,7 +31,7 @@ class OneObjectSealedInterfaceTests {
 
     @Test
     fun `correct enum class`() {
-        assertEquals(OneObjectSealedInterfaceEnum::class.java, OneObjectSealedInterface.sealedEnum.enumClass)
+        assertEquals(OneObjectSealedInterfaceEnum::class, OneObjectSealedInterface.sealedEnum.enumClass)
     }
 
     @Test

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClass.kt
@@ -19,10 +19,10 @@ package com.livefront.sealedenum.compilation.basic
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [TwoObjectSealedClass]
@@ -56,8 +56,8 @@ public object TwoObjectSealedClassSealedEnum : SealedEnum<TwoObjectSealedClass>,
     )
 
 
-    public override val enumClass: Class<TwoObjectSealedClassEnum>
-        get() = TwoObjectSealedClassEnum::class.java
+    public override val enumClass: KClass<TwoObjectSealedClassEnum>
+        get() = TwoObjectSealedClassEnum::class
 
     public override fun ordinalOf(obj: TwoObjectSealedClass): Int = when (obj) {
         TwoObjectSealedClass.FirstObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClassTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClassTests.kt
@@ -37,7 +37,7 @@ class TwoObjectSealedClassTests {
 
     @Test
     fun `correct enum class`() {
-        assertEquals(TwoObjectSealedClassEnum::class.java, TwoObjectSealedClassSealedEnum.enumClass)
+        assertEquals(TwoObjectSealedClassEnum::class, TwoObjectSealedClassSealedEnum.enumClass)
     }
 
     @Test

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedInterface.kt
@@ -19,10 +19,10 @@ package com.livefront.sealedenum.compilation.basic
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [TwoObjectSealedInterface]
@@ -56,8 +56,8 @@ public object TwoObjectSealedInterfaceSealedEnum : SealedEnum<TwoObjectSealedInt
     )
 
 
-    public override val enumClass: Class<TwoObjectSealedInterfaceEnum>
-        get() = TwoObjectSealedInterfaceEnum::class.java
+    public override val enumClass: KClass<TwoObjectSealedInterfaceEnum>
+        get() = TwoObjectSealedInterfaceEnum::class
 
     public override fun ordinalOf(obj: TwoObjectSealedInterface): Int = when (obj) {
         TwoObjectSealedInterface.FirstObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedInterfaceTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedInterfaceTests.kt
@@ -37,7 +37,7 @@ class TwoObjectSealedInterfaceTests {
 
     @Test
     fun `correct enum class`() {
-        assertEquals(TwoObjectSealedInterfaceEnum::class.java, TwoObjectSealedInterface.sealedEnum.enumClass)
+        assertEquals(TwoObjectSealedInterfaceEnum::class, TwoObjectSealedInterface.sealedEnum.enumClass)
     }
 
     @Test

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
@@ -23,10 +23,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [OneTypeParameterSealedClass]
@@ -62,8 +62,8 @@ public object OneTypeParameterSealedClassSealedEnum : SealedEnum<OneTypeParamete
     )
 
 
-    public override val enumClass: Class<OneTypeParameterSealedClassEnum>
-        get() = OneTypeParameterSealedClassEnum::class.java
+    public override val enumClass: KClass<OneTypeParameterSealedClassEnum>
+        get() = OneTypeParameterSealedClassEnum::class
 
     public override fun ordinalOf(obj: OneTypeParameterSealedClass<*>): Int = when (obj) {
         OneTypeParameterSealedClass.FirstObject -> 0
@@ -158,10 +158,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [TwoTypeParameterSealedClass]
@@ -196,8 +196,8 @@ public object TwoTypeParameterSealedClassSealedEnum : SealedEnum<TwoTypeParamete
     )
 
 
-    public override val enumClass: Class<TwoTypeParameterSealedClassEnum>
-        get() = TwoTypeParameterSealedClassEnum::class.java
+    public override val enumClass: KClass<TwoTypeParameterSealedClassEnum>
+        get() = TwoTypeParameterSealedClassEnum::class
 
     public override fun ordinalOf(obj: TwoTypeParameterSealedClass<*, *>): Int = when (obj) {
         TwoTypeParameterSealedClass.FirstObject -> 0
@@ -285,10 +285,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [LimitedTypeParameterSealedClass]
@@ -324,8 +324,8 @@ public object LimitedTypeParameterSealedClassSealedEnum :
     )
 
 
-    public override val enumClass: Class<LimitedTypeParameterSealedClassEnum>
-        get() = LimitedTypeParameterSealedClassEnum::class.java
+    public override val enumClass: KClass<LimitedTypeParameterSealedClassEnum>
+        get() = LimitedTypeParameterSealedClassEnum::class
 
     public override fun ordinalOf(obj: LimitedTypeParameterSealedClass<*, *>): Int = when (obj) {
         LimitedTypeParameterSealedClass.FirstObject -> 0
@@ -420,10 +420,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [MultipleBoundsSealedClass]
@@ -455,8 +455,8 @@ public object MultipleBoundsSealedClassSealedEnum : SealedEnum<MultipleBoundsSea
     )
 
 
-    public override val enumClass: Class<MultipleBoundsSealedClassEnum>
-        get() = MultipleBoundsSealedClassEnum::class.java
+    public override val enumClass: KClass<MultipleBoundsSealedClassEnum>
+        get() = MultipleBoundsSealedClassEnum::class
 
     public override fun ordinalOf(obj: MultipleBoundsSealedClass<*>): Int = when (obj) {
         MultipleBoundsSealedClass.FirstObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithAbstractBaseClasses.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithAbstractBaseClasses.kt
@@ -27,11 +27,11 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Any
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [SealedEnumWithAbstractBaseClasses]
@@ -64,8 +64,8 @@ public object SealedEnumWithAbstractBaseClassesSealedEnum :
     public override val values: List<SealedEnumWithAbstractBaseClasses> = emptyList()
 
 
-    public override val enumClass: Class<SealedEnumWithAbstractBaseClassesEnum>
-        get() = SealedEnumWithAbstractBaseClassesEnum::class.java
+    public override val enumClass: KClass<SealedEnumWithAbstractBaseClassesEnum>
+        get() = SealedEnumWithAbstractBaseClassesEnum::class
 
     public override fun ordinalOf(obj: SealedEnumWithAbstractBaseClasses): Int = throw
             AssertionError("Constructing a SealedEnumWithAbstractBaseClasses is impossible, since it has no sealed subclasses")
@@ -140,10 +140,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [SealedEnumWithAbstractBaseClassesCovariantType]
@@ -179,8 +179,8 @@ public object SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum :
             emptyList()
 
 
-    public override val enumClass: Class<SealedEnumWithAbstractBaseClassesCovariantTypeEnum>
-        get() = SealedEnumWithAbstractBaseClassesCovariantTypeEnum::class.java
+    public override val enumClass: KClass<SealedEnumWithAbstractBaseClassesCovariantTypeEnum>
+        get() = SealedEnumWithAbstractBaseClassesCovariantTypeEnum::class
 
     public override fun ordinalOf(obj: SealedEnumWithAbstractBaseClassesCovariantType<*>): Int =
             throw

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithInterfaces.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithInterfaces.kt
@@ -23,10 +23,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [EmptySealedClassWithInterface]
@@ -57,8 +57,8 @@ public object EmptySealedClassWithInterfaceSealedEnum : SealedEnum<EmptySealedCl
     public override val values: List<EmptySealedClassWithInterface> = emptyList()
 
 
-    public override val enumClass: Class<EmptySealedClassWithInterfaceEnum>
-        get() = EmptySealedClassWithInterfaceEnum::class.java
+    public override val enumClass: KClass<EmptySealedClassWithInterfaceEnum>
+        get() = EmptySealedClassWithInterfaceEnum::class
 
     public override fun ordinalOf(obj: EmptySealedClassWithInterface): Int = throw
             AssertionError("Constructing a EmptySealedClassWithInterface is impossible, since it has no sealed subclasses")
@@ -128,10 +128,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [OneObjectSealedClassWithInterface]
@@ -167,8 +167,8 @@ public object OneObjectSealedClassWithInterfaceSealedEnum :
     )
 
 
-    public override val enumClass: Class<OneObjectSealedClassWithInterfaceEnum>
-        get() = OneObjectSealedClassWithInterfaceEnum::class.java
+    public override val enumClass: KClass<OneObjectSealedClassWithInterfaceEnum>
+        get() = OneObjectSealedClassWithInterfaceEnum::class
 
     public override fun ordinalOf(obj: OneObjectSealedClassWithInterface): Int = when (obj) {
         OneObjectSealedClassWithInterface.FirstObject -> 0
@@ -252,10 +252,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [TwoObjectSealedClassWithGenericInterface]
@@ -296,8 +296,8 @@ public object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
     )
 
 
-    public override val enumClass: Class<TwoObjectSealedClassWithGenericInterfaceEnum>
-        get() = TwoObjectSealedClassWithGenericInterfaceEnum::class.java
+    public override val enumClass: KClass<TwoObjectSealedClassWithGenericInterfaceEnum>
+        get() = TwoObjectSealedClassWithGenericInterfaceEnum::class
 
     public override fun ordinalOf(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>): Int
             = when (obj) {
@@ -400,10 +400,10 @@ package com.livefront.sealedenum.compilation.generics
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [SealedClassWithGetterInterface]
@@ -438,8 +438,8 @@ public object SealedClassWithGetterInterfaceSealedEnum : SealedEnum<SealedClassW
     )
 
 
-    public override val enumClass: Class<SealedClassWithGetterInterfaceEnum>
-        get() = SealedClassWithGetterInterfaceEnum::class.java
+    public override val enumClass: KClass<SealedClassWithGetterInterfaceEnum>
+        get() = SealedClassWithGetterInterfaceEnum::class
 
     public override fun ordinalOf(obj: SealedClassWithGetterInterface): Int = when (obj) {
         SealedClassWithGetterInterface.FirstObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
@@ -26,10 +26,10 @@ package com.livefront.sealedenum.compilation.hierarchy
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [FirstClassHierarchy.A]
@@ -61,8 +61,8 @@ public object FirstClassHierarchy_ASealedEnum : SealedEnum<FirstClassHierarchy.A
     )
 
 
-    public override val enumClass: Class<FirstClassHierarchy_AEnum>
-        get() = FirstClassHierarchy_AEnum::class.java
+    public override val enumClass: KClass<FirstClassHierarchy_AEnum>
+        get() = FirstClassHierarchy_AEnum::class
 
     public override fun ordinalOf(obj: FirstClassHierarchy.A): Int = when (obj) {
         FirstClassHierarchy.A.B.C -> 0
@@ -130,10 +130,10 @@ package com.livefront.sealedenum.compilation.hierarchy
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [FirstClassHierarchy.A.B]
@@ -165,8 +165,8 @@ public object FirstClassHierarchy_A_BSealedEnum : SealedEnum<FirstClassHierarchy
     )
 
 
-    public override val enumClass: Class<FirstClassHierarchy_A_BEnum>
-        get() = FirstClassHierarchy_A_BEnum::class.java
+    public override val enumClass: KClass<FirstClassHierarchy_A_BEnum>
+        get() = FirstClassHierarchy_A_BEnum::class
 
     public override fun ordinalOf(obj: FirstClassHierarchy.A.B): Int = when (obj) {
         FirstClassHierarchy.A.B.C -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedInterfaceHierarchy.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedInterfaceHierarchy.kt
@@ -26,10 +26,10 @@ package com.livefront.sealedenum.compilation.hierarchy
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [FirstInterfaceHierarchy.A]
@@ -61,8 +61,8 @@ public object FirstInterfaceHierarchy_ASealedEnum : SealedEnum<FirstInterfaceHie
     )
 
 
-    public override val enumClass: Class<FirstInterfaceHierarchy_AEnum>
-        get() = FirstInterfaceHierarchy_AEnum::class.java
+    public override val enumClass: KClass<FirstInterfaceHierarchy_AEnum>
+        get() = FirstInterfaceHierarchy_AEnum::class
 
     public override fun ordinalOf(obj: FirstInterfaceHierarchy.A): Int = when (obj) {
         FirstInterfaceHierarchy.A.B.C -> 0
@@ -130,10 +130,10 @@ package com.livefront.sealedenum.compilation.hierarchy
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [FirstInterfaceHierarchy.A.B]
@@ -165,8 +165,8 @@ public object FirstInterfaceHierarchy_A_BSealedEnum : SealedEnum<FirstInterfaceH
     )
 
 
-    public override val enumClass: Class<FirstInterfaceHierarchy_A_BEnum>
-        get() = FirstInterfaceHierarchy_A_BEnum::class.java
+    public override val enumClass: KClass<FirstInterfaceHierarchy_A_BEnum>
+        get() = FirstInterfaceHierarchy_A_BEnum::class
 
     public override fun ordinalOf(obj: FirstInterfaceHierarchy.A.B): Int = when (obj) {
         FirstInterfaceHierarchy.A.B.C -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
@@ -17,10 +17,10 @@ package com.livefront.sealedenum.compilation.location
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [AlphaOutsideSealedClass]
@@ -52,8 +52,8 @@ public object AlphaOutsideSealedClassSealedEnum : SealedEnum<AlphaOutsideSealedC
     )
 
 
-    public override val enumClass: Class<AlphaOutsideSealedClassEnum>
-        get() = AlphaOutsideSealedClassEnum::class.java
+    public override val enumClass: KClass<AlphaOutsideSealedClassEnum>
+        get() = AlphaOutsideSealedClassEnum::class
 
     public override fun ordinalOf(obj: AlphaOutsideSealedClass): Int = when (obj) {
         AlphaFirstObject -> 0
@@ -134,10 +134,10 @@ package com.livefront.sealedenum.compilation.location
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [BetaOutsideSealedClass]
@@ -175,8 +175,8 @@ public object BetaOutsideSealedClassSealedEnum : SealedEnum<BetaOutsideSealedCla
     )
 
 
-    public override val enumClass: Class<BetaOutsideSealedClassEnum>
-        get() = BetaOutsideSealedClassEnum::class.java
+    public override val enumClass: KClass<BetaOutsideSealedClassEnum>
+        get() = BetaOutsideSealedClassEnum::class
 
     public override fun ordinalOf(obj: BetaOutsideSealedClass): Int = when (obj) {
         BetaFirstObject -> 0
@@ -273,10 +273,10 @@ package com.livefront.sealedenum.compilation.location
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [GammaOutsideSealedClass]
@@ -314,8 +314,8 @@ public object GammaOutsideSealedClassSealedEnum : SealedEnum<GammaOutsideSealedC
     )
 
 
-    public override val enumClass: Class<GammaOutsideSealedClassEnum>
-        get() = GammaOutsideSealedClassEnum::class.java
+    public override val enumClass: KClass<GammaOutsideSealedClassEnum>
+        get() = GammaOutsideSealedClassEnum::class
 
     public override fun ordinalOf(obj: GammaOutsideSealedClass): Int = when (obj) {
         GammaOutsideSealedClass.GammaSecondObject -> 0
@@ -409,10 +409,10 @@ package com.livefront.sealedenum.compilation.location
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [DeltaOutsideSealedClass]
@@ -446,8 +446,8 @@ public object DeltaOutsideSealedClassSealedEnum : SealedEnum<DeltaOutsideSealedC
     )
 
 
-    public override val enumClass: Class<DeltaOutsideSealedClassEnum>
-        get() = DeltaOutsideSealedClassEnum::class.java
+    public override val enumClass: KClass<DeltaOutsideSealedClassEnum>
+        get() = DeltaOutsideSealedClassEnum::class
 
     public override fun ordinalOf(obj: DeltaOutsideSealedClass): Int = when (obj) {
         DeltaOutsideSealedClass.DeltaObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/SplitAcrossFilesSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/SplitAcrossFilesSealedClass.kt
@@ -16,10 +16,10 @@ package com.livefront.sealedenum.compilation.location
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [SplitAcrossFilesSealedClass]
@@ -55,8 +55,8 @@ public object SplitAcrossFilesSealedClassSealedEnum : SealedEnum<SplitAcrossFile
     )
 
 
-    public override val enumClass: Class<SplitAcrossFilesSealedClassEnum>
-        get() = SplitAcrossFilesSealedClassEnum::class.java
+    public override val enumClass: KClass<SplitAcrossFilesSealedClassEnum>
+        get() = SplitAcrossFilesSealedClassEnum::class
 
     public override fun ordinalOf(obj: SplitAcrossFilesSealedClass): Int = when (obj) {
         SplitAcrossFilesSubclassA -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
@@ -68,10 +68,10 @@ package com.livefront.sealedenum.compilation.traversal
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [Tree]
@@ -129,8 +129,8 @@ public object TreeLevelOrderSealedEnum : SealedEnum<Tree>,
     )
 
 
-    public override val enumClass: Class<TreeLevelOrderEnum>
-        get() = TreeLevelOrderEnum::class.java
+    public override val enumClass: KClass<TreeLevelOrderEnum>
+        get() = TreeLevelOrderEnum::class
 
     public override fun ordinalOf(obj: Tree): Int = when (obj) {
         Tree.A -> 0
@@ -307,8 +307,8 @@ public object TreePostOrderSealedEnum : SealedEnum<Tree>,
     )
 
 
-    public override val enumClass: Class<TreePostOrderEnum>
-        get() = TreePostOrderEnum::class.java
+    public override val enumClass: KClass<TreePostOrderEnum>
+        get() = TreePostOrderEnum::class
 
     public override fun ordinalOf(obj: Tree): Int = when (obj) {
         Tree.B.C.F.G -> 0
@@ -485,8 +485,8 @@ public object TreeInOrderSealedEnum : SealedEnum<Tree>,
     )
 
 
-    public override val enumClass: Class<TreeInOrderEnum>
-        get() = TreeInOrderEnum::class.java
+    public override val enumClass: KClass<TreeInOrderEnum>
+        get() = TreeInOrderEnum::class
 
     public override fun ordinalOf(obj: Tree): Int = when (obj) {
         Tree.A -> 0
@@ -662,8 +662,8 @@ public object TreePreOrderSealedEnum : SealedEnum<Tree>,
     )
 
 
-    public override val enumClass: Class<TreePreOrderEnum>
-        get() = TreePreOrderEnum::class.java
+    public override val enumClass: KClass<TreePreOrderEnum>
+        get() = TreePreOrderEnum::class
 
     public override fun ordinalOf(obj: Tree): Int = when (obj) {
         Tree.A -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnum.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnum.kt
@@ -42,10 +42,10 @@ package com.livefront.sealedenum.compilation.usecases
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [Environments]
@@ -85,8 +85,8 @@ public object EnvironmentsSealedEnum : SealedEnum<Environments>,
     )
 
 
-    public override val enumClass: Class<EnvironmentsEnum>
-        get() = EnvironmentsEnum::class.java
+    public override val enumClass: KClass<EnvironmentsEnum>
+        get() = EnvironmentsEnum::class
 
     public override fun ordinalOf(obj: Environments): Int = when (obj) {
         Environments.Http.Livefront -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnumTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnumTests.kt
@@ -45,7 +45,7 @@ class EnvironmentsSealedEnumTests {
     @Test
     fun `environment manager from sealed enum`() {
         val environmentManager = EnvironmentManager(
-            enumClass = Environments.sealedEnum.enumClass,
+            enumClass = Environments.sealedEnum.enumClass.java,
             defaultEnvironment = Environments.Https.Livefront.enum
         )
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/PrivateInterfaceSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/PrivateInterfaceSealedClass.kt
@@ -23,10 +23,10 @@ package com.livefront.sealedenum.compilation.visibility
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [PrivateInterfaceSealedClass]
@@ -60,8 +60,8 @@ public object PrivateInterfaceSealedClassSealedEnum : SealedEnum<PrivateInterfac
     )
 
 
-    public override val enumClass: Class<PrivateInterfaceSealedClassEnum>
-        get() = PrivateInterfaceSealedClassEnum::class.java
+    public override val enumClass: KClass<PrivateInterfaceSealedClassEnum>
+        get() = PrivateInterfaceSealedClassEnum::class
 
     public override fun ordinalOf(obj: PrivateInterfaceSealedClass): Int = when (obj) {
         PrivateInterfaceSealedClass.FirstObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/PrivateInterfaceSealedClassTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/PrivateInterfaceSealedClassTests.kt
@@ -42,7 +42,7 @@ class PrivateInterfaceSealedClassTests {
     @Test
     fun `sealed class has correct enum class`() {
         assertEquals(
-            PrivateInterfaceSealedClassEnum::class.java,
+            PrivateInterfaceSealedClassEnum::class,
             PrivateInterfaceSealedClass.sealedEnum.enumClass
         )
     }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClass.kt
@@ -28,10 +28,10 @@ package com.livefront.sealedenum.compilation.visibility
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class
@@ -77,8 +77,8 @@ public object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEn
 
 
     public override val enumClass:
-            Class<ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>
-        get() = ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum::class.java
+            KClass<ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>
+        get() = ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum::class
 
     public override fun ordinalOf(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass):
             Int = when (obj) {

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassTests.kt
@@ -56,7 +56,7 @@ class ProtectedInterfaceSealedClassTests {
     @Test
     fun `sealed class has correct enum class`() {
         assertEquals(
-            ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum::class.java,
+            ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum::class,
             ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.sealedEnum.enumClass
         )
     }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClass.kt
@@ -29,10 +29,10 @@ package com.livefront.sealedenum.compilation.visibility
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class
@@ -87,9 +87,9 @@ public object
 
 
     public override val enumClass:
-            Class<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum>
+            KClass<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum>
         get() =
-                ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum::class.java
+                ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum::class
 
     public override
             fun ordinalOf(obj: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass):

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClassTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClassTests.kt
@@ -44,7 +44,7 @@ class ProtectedInterfaceSealedClassWithDifferentPackageBaseClassTests {
     @Test
     fun `sealed class has correct enum class`() {
         assertEquals(
-            ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum::class.java,
+            ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum::class,
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.sealedEnum.enumClass
         )
     }

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
@@ -23,10 +23,10 @@ package com.livefront.sealedenum.compilation.visibility
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [InternalObjectsSealedClass]
@@ -62,8 +62,8 @@ public object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsS
     )
 
 
-    public override val enumClass: Class<InternalObjectsSealedClassEnum>
-        get() = InternalObjectsSealedClassEnum::class.java
+    public override val enumClass: KClass<InternalObjectsSealedClassEnum>
+        get() = InternalObjectsSealedClassEnum::class
 
     public override fun ordinalOf(obj: InternalObjectsSealedClass): Int = when (obj) {
         InternalObjectsSealedClass.FirstObject -> 0
@@ -158,10 +158,10 @@ package com.livefront.sealedenum.compilation.visibility
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [InternalSealedClass]
@@ -195,8 +195,8 @@ internal object InternalSealedClassSealedEnum : SealedEnum<InternalSealedClass>,
     )
 
 
-    public override val enumClass: Class<InternalSealedClassEnum>
-        get() = InternalSealedClassEnum::class.java
+    public override val enumClass: KClass<InternalSealedClassEnum>
+        get() = InternalSealedClassEnum::class
 
     public override fun ordinalOf(obj: InternalSealedClass): Int = when (obj) {
         InternalSealedClass.FirstObject -> 0
@@ -278,10 +278,10 @@ package com.livefront.sealedenum.compilation.visibility
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [InternalCompanionSealedClass]
@@ -315,8 +315,8 @@ public object InternalCompanionSealedClassSealedEnum : SealedEnum<InternalCompan
     )
 
 
-    public override val enumClass: Class<InternalCompanionSealedClassEnum>
-        get() = InternalCompanionSealedClassEnum::class.java
+    public override val enumClass: KClass<InternalCompanionSealedClassEnum>
+        get() = InternalCompanionSealedClassEnum::class
 
     public override fun ordinalOf(obj: InternalCompanionSealedClass): Int = when (obj) {
         InternalCompanionSealedClass.FirstObject -> 0
@@ -403,10 +403,10 @@ package com.livefront.sealedenum.compilation.visibility
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [InternalSealedAndCompanionSealedClass]
@@ -443,8 +443,8 @@ internal object InternalSealedAndCompanionSealedClassSealedEnum :
     )
 
 
-    public override val enumClass: Class<InternalSealedAndCompanionSealedClassEnum>
-        get() = InternalSealedAndCompanionSealedClassEnum::class.java
+    public override val enumClass: KClass<InternalSealedAndCompanionSealedClassEnum>
+        get() = InternalSealedAndCompanionSealedClassEnum::class
 
     public override fun ordinalOf(obj: InternalSealedAndCompanionSealedClass): Int = when (obj) {
         InternalSealedAndCompanionSealedClass.FirstObject -> 0

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClassTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClassTests.kt
@@ -60,7 +60,7 @@ class VisibilitySealedClassTests {
 
         @Test
         fun `correct enum class`() {
-            assertEquals(InternalObjectsSealedClassEnum::class.java, InternalObjectsSealedClass.sealedEnum.enumClass)
+            assertEquals(InternalObjectsSealedClassEnum::class, InternalObjectsSealedClass.sealedEnum.enumClass)
         }
 
         @Test
@@ -116,7 +116,7 @@ class VisibilitySealedClassTests {
 
         @Test
         fun `correct enum class`() {
-            assertEquals(InternalSealedClassEnum::class.java, InternalSealedClass.sealedEnum.enumClass)
+            assertEquals(InternalSealedClassEnum::class, InternalSealedClass.sealedEnum.enumClass)
         }
 
         @Test
@@ -169,7 +169,7 @@ class VisibilitySealedClassTests {
         @Test
         fun `correct enum class`() {
             assertEquals(
-                InternalCompanionSealedClassEnum::class.java,
+                InternalCompanionSealedClassEnum::class,
                 InternalCompanionSealedClass.sealedEnum.enumClass
             )
         }
@@ -231,7 +231,7 @@ class VisibilitySealedClassTests {
         @Test
         fun `correct enum class`() {
             assertEquals(
-                InternalSealedAndCompanionSealedClassEnum::class.java,
+                InternalSealedAndCompanionSealedClassEnum::class,
                 InternalSealedAndCompanionSealedClass.sealedEnum.enumClass
             )
         }

--- a/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameName.kt
+++ b/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameName.kt
@@ -20,10 +20,10 @@ package com.livefront.sealedenum.compilation.ksp
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [NestedObjectsWithSameName.Companion.EmptySealedClass]
@@ -57,8 +57,8 @@ public object NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum :
             emptyList()
 
 
-    public override val enumClass: Class<NestedObjectsWithSameName_Companion_EmptySealedClassEnum>
-        get() = NestedObjectsWithSameName_Companion_EmptySealedClassEnum::class.java
+    public override val enumClass: KClass<NestedObjectsWithSameName_Companion_EmptySealedClassEnum>
+        get() = NestedObjectsWithSameName_Companion_EmptySealedClassEnum::class
 
     public override fun ordinalOf(obj: NestedObjectsWithSameName.Companion.EmptySealedClass): Int =
             throw

--- a/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameNameTests.kt
+++ b/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameNameTests.kt
@@ -39,7 +39,7 @@ class NestedObjectsWithSameNameTests {
     @Test
     fun `correct enum class`() {
         assertEquals(
-            NestedObjectsWithSameName_Companion_EmptySealedClassEnum::class.java,
+            NestedObjectsWithSameName_Companion_EmptySealedClassEnum::class,
             NestedObjectsWithSameName.Companion.EmptySealedClass.sealedEnum.enumClass
         )
     }

--- a/processing-tests/processor-tests/src/test/kotlin/com/livefront/sealedenum/compilation/kitchensink/JavaBaseClasses.kt
+++ b/processing-tests/processor-tests/src/test/kotlin/com/livefront/sealedenum/compilation/kitchensink/JavaBaseClasses.kt
@@ -45,11 +45,11 @@ package com.livefront.sealedenum.compilation.kitchensink
 import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
-import java.lang.Class
 import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
+import kotlin.reflect.KClass
 
 /**
  * An isomorphic enum for the sealed class [JavaBaseClassesSealedClass]
@@ -91,8 +91,8 @@ public object JavaBaseClassesSealedClassSealedEnum : SealedEnum<JavaBaseClassesS
     )
 
 
-    public override val enumClass: Class<JavaBaseClassesSealedClassEnum>
-        get() = JavaBaseClassesSealedClassEnum::class.java
+    public override val enumClass: KClass<JavaBaseClassesSealedClassEnum>
+        get() = JavaBaseClassesSealedClassEnum::class
 
     public override fun ordinalOf(obj: JavaBaseClassesSealedClass<*>): Int = when (obj) {
         JavaBaseClassesSealedClass.FirstObject -> 0

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -1,6 +1,6 @@
 public abstract interface class com/livefront/sealedenum/EnumForSealedEnumProvider {
 	public abstract fun enumToSealedObject (Ljava/lang/Enum;)Ljava/lang/Object;
-	public abstract fun getEnumClass ()Ljava/lang/Class;
+	public abstract fun getEnumClass ()Lkotlin/reflect/KClass;
 	public abstract fun sealedObjectToEnum (Ljava/lang/Object;)Ljava/lang/Enum;
 }
 
@@ -26,7 +26,7 @@ public final class com/livefront/sealedenum/SealedEnum$DefaultImpls {
 }
 
 public final class com/livefront/sealedenum/SealedEnumKt {
-	public static final fun createSealedEnumFromEnumArray ([Ljava/lang/Enum;Ljava/lang/Class;)Lcom/livefront/sealedenum/SealedEnumWithEnumProvider;
+	public static final fun createSealedEnumFromEnumArray ([Ljava/lang/Enum;Lkotlin/reflect/KClass;)Lcom/livefront/sealedenum/SealedEnumWithEnumProvider;
 }
 
 public abstract interface class com/livefront/sealedenum/SealedEnumWithEnumProvider : com/livefront/sealedenum/EnumForSealedEnumProvider, com/livefront/sealedenum/SealedEnum {

--- a/runtime/src/main/kotlin/com/livefront/sealedenum/EnumForSealedEnumProvider.kt
+++ b/runtime/src/main/kotlin/com/livefront/sealedenum/EnumForSealedEnumProvider.kt
@@ -1,5 +1,7 @@
 package com.livefront.sealedenum
 
+import kotlin.reflect.KClass
+
 /**
  * Defines a provider for interoperability between a [SealedEnum] for type [T] and a normal enum class [E].
  */
@@ -19,5 +21,5 @@ public interface EnumForSealedEnumProvider<T, E : Enum<E>> {
     /**
      * The class object for the enum.
      */
-    public val enumClass: Class<E>
+    public val enumClass: KClass<E>
 }

--- a/runtime/src/main/kotlin/com/livefront/sealedenum/SealedEnum.kt
+++ b/runtime/src/main/kotlin/com/livefront/sealedenum/SealedEnum.kt
@@ -1,5 +1,7 @@
 package com.livefront.sealedenum
 
+import kotlin.reflect.KClass
+
 /**
  * An interface providing `Enum`-like methods in a generic manner, for sealed classes that only have objects as
  * subclasses.
@@ -39,20 +41,20 @@ public interface SealedEnum<T> : Comparator<T> {
  * Creates a [SealedEnumWithEnumProvider] for the enum [E].
  */
 public inline fun <reified E : Enum<E>> createSealedEnumFromEnum(): SealedEnumWithEnumProvider<E, E> =
-    createSealedEnumFromEnumArray(enumValues(), E::class.java)
+    createSealedEnumFromEnumArray(enumValues(), E::class)
 
 /**
  * Creates a [SealedEnumWithEnumProvider] for the enum [E] with the given array of enum values.
  */
 public fun <E : Enum<E>> createSealedEnumFromEnumArray(
     values: Array<E>,
-    enumClass: Class<E>
+    enumClass: KClass<E>
 ): SealedEnumWithEnumProvider<E, E> = object : SealedEnumWithEnumProvider<E, E> {
     val nameToValueMap: Map<String, E> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         values.associateBy { it.name }
     }
 
-    override val enumClass: Class<E> = enumClass
+    override val enumClass: KClass<E> = enumClass
 
     override val values: List<E> = values.toList()
 

--- a/runtime/src/test/kotlin/com/livefront/sealedenum/CreateSealedEnumFromEnumTests.kt
+++ b/runtime/src/test/kotlin/com/livefront/sealedenum/CreateSealedEnumFromEnumTests.kt
@@ -102,7 +102,7 @@ class CreateSealedEnumFromEnumTests {
 
     @Test
     fun `verify enum class is correct`() {
-        assertEquals(AlphaEnum::class.java, alphaEnumSealedEnum.enumClass)
+        assertEquals(AlphaEnum::class, alphaEnumSealedEnum.enumClass)
     }
 
     @Test


### PR DESCRIPTION
Fixes #125 .

This is a breaking change to convert current usages of `Class` to `KClass` in a couple spots in the API.

This allows the `runtime` module to be fully multiplatform to setup #81 , as `KClass` is not specific to `jvm` targets like `Class` is.

This was previously part of #78 , but spun out here for ease of reviewing the API change without adjusting the entire project to be multiplatform.