### PR TITLE
Replace equality checks on sealed objects with `is` checks (fixes #129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,19 +88,21 @@ sealed class Alpha {
 will generate the following object:
 ```kotlin
 object AlphaSealedEnum : SealedEnum<Alpha> {
-    override val values: List<Alpha> = listOf(
-        Alpha.Beta,
-        Alpha.Gamma
-    )
+    override val values: List<Alpha> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Alpha.Beta,
+            Alpha.Gamma
+        )
+    }
 
     override fun ordinalOf(obj: Alpha): Int = when (obj) {
-        Alpha.Beta -> 0
-        Alpha.Gamma -> 1
+        is Alpha.Beta -> 0
+        is Alpha.Gamma -> 1
     }
 
     override fun nameOf(obj: AlphaSealedEnum): String = when (obj) {
-        Alpha.Beta -> "Alpha_Beta"
-        Alpha.Gamma -> "Alpha_Gamma"
+        is Alpha.Beta -> "Alpha_Beta"
+        is Alpha.Gamma -> "Alpha_Gamma"
     }
 
     override fun valueOf(name: String): AlphaSealedEnum = when (name) {
@@ -150,22 +152,24 @@ sealed class Alpha {
 will generate two objects:
 ```kotlin
 object AlphaLevelOrderSealedEnum : SealedEnum<Alpha> {
-    override val values: List<Alpha> = listOf(
-        Alpha.Delta,
-        Alpha.Beta.Gamma,
-        Alpha.Epsilon.Zeta
-    )
+    override val values: List<Alpha> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Alpha.Delta,
+            Alpha.Beta.Gamma,
+            Alpha.Epsilon.Zeta
+        )
+    }
 
     override fun ordinalOf(obj: Alpha): Int = when (obj) {
-        Alpha.Delta -> 0
-        Alpha.Beta.Gamma -> 1
-        Alpha.Epsilon.Zeta -> 2
+        is Alpha.Delta -> 0
+        is Alpha.Beta.Gamma -> 1
+        is Alpha.Epsilon.Zeta -> 2
     }
 
     override fun nameOf(obj: AlphaLevelOrderSealedEnum): String = when (obj) {
-        Alpha.Delta -> "Alpha_Delta"
-        Alpha.Beta.Gamma -> "Alpha_Beta_Gamma"
-        Alpha.Epsilon.Zeta -> "Alpha_Epsilon_Zeta"
+        is Alpha.Delta -> "Alpha_Delta"
+        is Alpha.Beta.Gamma -> "Alpha_Beta_Gamma"
+        is Alpha.Epsilon.Zeta -> "Alpha_Epsilon_Zeta"
     }
 
     override fun valueOf(name: String): AlphaLevelOrderSealedEnum = when (name) {
@@ -177,22 +181,24 @@ object AlphaLevelOrderSealedEnum : SealedEnum<Alpha> {
 }
 
 object AlphaInOrderSealedEnum : SealedEnum<Alpha> {
-    override val values: List<Alpha> = listOf(
-        Alpha.Beta.Gamma,
-        Alpha.Delta,
-        Alpha.Epsilon.Zeta
-    )
+    override val values: List<Alpha> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Alpha.Beta.Gamma,
+            Alpha.Delta,
+            Alpha.Epsilon.Zeta
+        )
+    }
 
     override fun ordinalOf(obj: Alpha): Int = when (obj) {
-        Alpha.Beta.Gamma -> 0
-        Alpha.Delta -> 1
-        Alpha.Epsilon.Zeta -> 2
+        is Alpha.Beta.Gamma -> 0
+        is Alpha.Delta -> 1
+        is Alpha.Epsilon.Zeta -> 2
     }
 
     override fun nameOf(obj: AlphaInOrderSealedEnum): String = when (obj) {
-        Alpha.Beta.Gamma -> "Alpha_Beta_Gamma"
-        Alpha.Delta -> "Alpha_Delta"
-        Alpha.Epsilon.Zeta -> "Alpha_Epsilon_Zeta"
+        is Alpha.Beta.Gamma -> "Alpha_Beta_Gamma"
+        is Alpha.Delta -> "Alpha_Delta"
+        is Alpha.Epsilon.Zeta -> "Alpha_Epsilon_Zeta"
     }
 
     override fun valueOf(name: String): AlphaInOrderSealedEnum = when (name) {
@@ -287,14 +293,16 @@ object AlphaSealedEnum : SealedEnum<Alpha>, SealedEnumWithEnumProvider<Alpha, Al
         EnumForSealedEnumProvider<Alpha, AlphaEnum> {
     ...
 
-    override val values: List<Alpha> = listOf(
-        Alpha.Beta,
-        Alpha.Gamma
-    )
+    override val values: List<Alpha> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Alpha.Beta,
+            Alpha.Gamma
+        )
+    }
 
     override fun sealedObjectToEnum(obj: Alpha): AlphaEnum = when (obj) {
-        Alpha.Beta -> AlphaEnum.Alpha_Beta
-        Alpha.Gamma -> AlphaEnum.Alpha_Gamma
+        is Alpha.Beta -> AlphaEnum.Alpha_Beta
+        is Alpha.Gamma -> AlphaEnum.Alpha_Gamma
     }
 
     override fun enumToSealedObject(enum: AlphaEnum): Alpha = when (enum) {

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedClass.kt
@@ -16,6 +16,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -43,7 +44,10 @@ public val EmptySealedClassEnum.sealedObject: EmptySealedClass
 public object EmptySealedClassSealedEnum : SealedEnum<EmptySealedClass>,
         SealedEnumWithEnumProvider<EmptySealedClass, EmptySealedClassEnum>,
         EnumForSealedEnumProvider<EmptySealedClass, EmptySealedClassEnum> {
-    public override val values: List<EmptySealedClass> = emptyList()
+    public override val values: List<EmptySealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        emptyList()
+    }
 
 
     public override val enumClass: KClass<EmptySealedClassEnum>

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/EmptySealedInterface.kt
@@ -16,6 +16,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -43,7 +44,10 @@ public val EmptySealedInterfaceEnum.sealedObject: EmptySealedInterface
 public object EmptySealedInterfaceSealedEnum : SealedEnum<EmptySealedInterface>,
         SealedEnumWithEnumProvider<EmptySealedInterface, EmptySealedInterfaceEnum>,
         EnumForSealedEnumProvider<EmptySealedInterface, EmptySealedInterfaceEnum> {
-    public override val values: List<EmptySealedInterface> = emptyList()
+    public override val values: List<EmptySealedInterface> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        emptyList()
+    }
 
 
     public override val enumClass: KClass<EmptySealedInterfaceEnum>

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedClass.kt
@@ -18,6 +18,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -47,20 +48,23 @@ public val OneObjectSealedClassEnum.sealedObject: OneObjectSealedClass
 public object OneObjectSealedClassSealedEnum : SealedEnum<OneObjectSealedClass>,
         SealedEnumWithEnumProvider<OneObjectSealedClass, OneObjectSealedClassEnum>,
         EnumForSealedEnumProvider<OneObjectSealedClass, OneObjectSealedClassEnum> {
-    public override val values: List<OneObjectSealedClass> = listOf(
-        OneObjectSealedClass.FirstObject
-    )
+    public override val values: List<OneObjectSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            OneObjectSealedClass.FirstObject
+        )
+    }
 
 
     public override val enumClass: KClass<OneObjectSealedClassEnum>
         get() = OneObjectSealedClassEnum::class
 
     public override fun ordinalOf(obj: OneObjectSealedClass): Int = when (obj) {
-        OneObjectSealedClass.FirstObject -> 0
+        is OneObjectSealedClass.FirstObject -> 0
     }
 
     public override fun nameOf(obj: OneObjectSealedClass): String = when (obj) {
-        OneObjectSealedClass.FirstObject -> "OneObjectSealedClass_FirstObject"
+        is OneObjectSealedClass.FirstObject -> "OneObjectSealedClass_FirstObject"
     }
 
     public override fun valueOf(name: String): OneObjectSealedClass = when (name) {
@@ -70,7 +74,7 @@ public object OneObjectSealedClassSealedEnum : SealedEnum<OneObjectSealedClass>,
 
     public override fun sealedObjectToEnum(obj: OneObjectSealedClass): OneObjectSealedClassEnum =
             when (obj) {
-        OneObjectSealedClass.FirstObject ->
+        is OneObjectSealedClass.FirstObject ->
                 OneObjectSealedClassEnum.OneObjectSealedClass_FirstObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/OneObjectSealedInterface.kt
@@ -18,6 +18,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -47,20 +48,23 @@ public val OneObjectSealedInterfaceEnum.sealedObject: OneObjectSealedInterface
 public object OneObjectSealedInterfaceSealedEnum : SealedEnum<OneObjectSealedInterface>,
         SealedEnumWithEnumProvider<OneObjectSealedInterface, OneObjectSealedInterfaceEnum>,
         EnumForSealedEnumProvider<OneObjectSealedInterface, OneObjectSealedInterfaceEnum> {
-    public override val values: List<OneObjectSealedInterface> = listOf(
-        OneObjectSealedInterface.FirstObject
-    )
+    public override val values: List<OneObjectSealedInterface> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            OneObjectSealedInterface.FirstObject
+        )
+    }
 
 
     public override val enumClass: KClass<OneObjectSealedInterfaceEnum>
         get() = OneObjectSealedInterfaceEnum::class
 
     public override fun ordinalOf(obj: OneObjectSealedInterface): Int = when (obj) {
-        OneObjectSealedInterface.FirstObject -> 0
+        is OneObjectSealedInterface.FirstObject -> 0
     }
 
     public override fun nameOf(obj: OneObjectSealedInterface): String = when (obj) {
-        OneObjectSealedInterface.FirstObject -> "OneObjectSealedInterface_FirstObject"
+        is OneObjectSealedInterface.FirstObject -> "OneObjectSealedInterface_FirstObject"
     }
 
     public override fun valueOf(name: String): OneObjectSealedInterface = when (name) {
@@ -70,7 +74,7 @@ public object OneObjectSealedInterfaceSealedEnum : SealedEnum<OneObjectSealedInt
 
     public override fun sealedObjectToEnum(obj: OneObjectSealedInterface):
             OneObjectSealedInterfaceEnum = when (obj) {
-        OneObjectSealedInterface.FirstObject ->
+        is OneObjectSealedInterface.FirstObject ->
                 OneObjectSealedInterfaceEnum.OneObjectSealedInterface_FirstObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedClass.kt
@@ -20,6 +20,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -50,23 +51,26 @@ public val TwoObjectSealedClassEnum.sealedObject: TwoObjectSealedClass
 public object TwoObjectSealedClassSealedEnum : SealedEnum<TwoObjectSealedClass>,
         SealedEnumWithEnumProvider<TwoObjectSealedClass, TwoObjectSealedClassEnum>,
         EnumForSealedEnumProvider<TwoObjectSealedClass, TwoObjectSealedClassEnum> {
-    public override val values: List<TwoObjectSealedClass> = listOf(
-        TwoObjectSealedClass.FirstObject,
-        TwoObjectSealedClass.SecondObject
-    )
+    public override val values: List<TwoObjectSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            TwoObjectSealedClass.FirstObject,
+            TwoObjectSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<TwoObjectSealedClassEnum>
         get() = TwoObjectSealedClassEnum::class
 
     public override fun ordinalOf(obj: TwoObjectSealedClass): Int = when (obj) {
-        TwoObjectSealedClass.FirstObject -> 0
-        TwoObjectSealedClass.SecondObject -> 1
+        is TwoObjectSealedClass.FirstObject -> 0
+        is TwoObjectSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: TwoObjectSealedClass): String = when (obj) {
-        TwoObjectSealedClass.FirstObject -> "TwoObjectSealedClass_FirstObject"
-        TwoObjectSealedClass.SecondObject -> "TwoObjectSealedClass_SecondObject"
+        is TwoObjectSealedClass.FirstObject -> "TwoObjectSealedClass_FirstObject"
+        is TwoObjectSealedClass.SecondObject -> "TwoObjectSealedClass_SecondObject"
     }
 
     public override fun valueOf(name: String): TwoObjectSealedClass = when (name) {
@@ -77,9 +81,9 @@ public object TwoObjectSealedClassSealedEnum : SealedEnum<TwoObjectSealedClass>,
 
     public override fun sealedObjectToEnum(obj: TwoObjectSealedClass): TwoObjectSealedClassEnum =
             when (obj) {
-        TwoObjectSealedClass.FirstObject ->
+        is TwoObjectSealedClass.FirstObject ->
                 TwoObjectSealedClassEnum.TwoObjectSealedClass_FirstObject
-        TwoObjectSealedClass.SecondObject ->
+        is TwoObjectSealedClass.SecondObject ->
                 TwoObjectSealedClassEnum.TwoObjectSealedClass_SecondObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedInterface.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/basic/TwoObjectSealedInterface.kt
@@ -20,6 +20,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -50,23 +51,26 @@ public val TwoObjectSealedInterfaceEnum.sealedObject: TwoObjectSealedInterface
 public object TwoObjectSealedInterfaceSealedEnum : SealedEnum<TwoObjectSealedInterface>,
         SealedEnumWithEnumProvider<TwoObjectSealedInterface, TwoObjectSealedInterfaceEnum>,
         EnumForSealedEnumProvider<TwoObjectSealedInterface, TwoObjectSealedInterfaceEnum> {
-    public override val values: List<TwoObjectSealedInterface> = listOf(
-        TwoObjectSealedInterface.FirstObject,
-        TwoObjectSealedInterface.SecondObject
-    )
+    public override val values: List<TwoObjectSealedInterface> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            TwoObjectSealedInterface.FirstObject,
+            TwoObjectSealedInterface.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<TwoObjectSealedInterfaceEnum>
         get() = TwoObjectSealedInterfaceEnum::class
 
     public override fun ordinalOf(obj: TwoObjectSealedInterface): Int = when (obj) {
-        TwoObjectSealedInterface.FirstObject -> 0
-        TwoObjectSealedInterface.SecondObject -> 1
+        is TwoObjectSealedInterface.FirstObject -> 0
+        is TwoObjectSealedInterface.SecondObject -> 1
     }
 
     public override fun nameOf(obj: TwoObjectSealedInterface): String = when (obj) {
-        TwoObjectSealedInterface.FirstObject -> "TwoObjectSealedInterface_FirstObject"
-        TwoObjectSealedInterface.SecondObject -> "TwoObjectSealedInterface_SecondObject"
+        is TwoObjectSealedInterface.FirstObject -> "TwoObjectSealedInterface_FirstObject"
+        is TwoObjectSealedInterface.SecondObject -> "TwoObjectSealedInterface_SecondObject"
     }
 
     public override fun valueOf(name: String): TwoObjectSealedInterface = when (name) {
@@ -77,9 +81,9 @@ public object TwoObjectSealedInterfaceSealedEnum : SealedEnum<TwoObjectSealedInt
 
     public override fun sealedObjectToEnum(obj: TwoObjectSealedInterface):
             TwoObjectSealedInterfaceEnum = when (obj) {
-        TwoObjectSealedInterface.FirstObject ->
+        is TwoObjectSealedInterface.FirstObject ->
                 TwoObjectSealedInterfaceEnum.TwoObjectSealedInterface_FirstObject
-        TwoObjectSealedInterface.SecondObject ->
+        is TwoObjectSealedInterface.SecondObject ->
                 TwoObjectSealedInterfaceEnum.TwoObjectSealedInterface_SecondObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/GenericSealedClass.kt
@@ -24,6 +24,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -55,26 +56,29 @@ public val OneTypeParameterSealedClassEnum.sealedObject: OneTypeParameterSealedC
 public object OneTypeParameterSealedClassSealedEnum : SealedEnum<OneTypeParameterSealedClass<*>>,
         SealedEnumWithEnumProvider<OneTypeParameterSealedClass<*>, OneTypeParameterSealedClassEnum>,
         EnumForSealedEnumProvider<OneTypeParameterSealedClass<*>, OneTypeParameterSealedClassEnum> {
-    public override val values: List<OneTypeParameterSealedClass<*>> = listOf(
-        OneTypeParameterSealedClass.FirstObject,
-        OneTypeParameterSealedClass.SecondObject,
-        OneTypeParameterSealedClass.ThirdObject
-    )
+    public override val values: List<OneTypeParameterSealedClass<*>> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            OneTypeParameterSealedClass.FirstObject,
+            OneTypeParameterSealedClass.SecondObject,
+            OneTypeParameterSealedClass.ThirdObject
+        )
+    }
 
 
     public override val enumClass: KClass<OneTypeParameterSealedClassEnum>
         get() = OneTypeParameterSealedClassEnum::class
 
     public override fun ordinalOf(obj: OneTypeParameterSealedClass<*>): Int = when (obj) {
-        OneTypeParameterSealedClass.FirstObject -> 0
-        OneTypeParameterSealedClass.SecondObject -> 1
-        OneTypeParameterSealedClass.ThirdObject -> 2
+        is OneTypeParameterSealedClass.FirstObject -> 0
+        is OneTypeParameterSealedClass.SecondObject -> 1
+        is OneTypeParameterSealedClass.ThirdObject -> 2
     }
 
     public override fun nameOf(obj: OneTypeParameterSealedClass<*>): String = when (obj) {
-        OneTypeParameterSealedClass.FirstObject -> "OneTypeParameterSealedClass_FirstObject"
-        OneTypeParameterSealedClass.SecondObject -> "OneTypeParameterSealedClass_SecondObject"
-        OneTypeParameterSealedClass.ThirdObject -> "OneTypeParameterSealedClass_ThirdObject"
+        is OneTypeParameterSealedClass.FirstObject -> "OneTypeParameterSealedClass_FirstObject"
+        is OneTypeParameterSealedClass.SecondObject -> "OneTypeParameterSealedClass_SecondObject"
+        is OneTypeParameterSealedClass.ThirdObject -> "OneTypeParameterSealedClass_ThirdObject"
     }
 
     public override fun valueOf(name: String): OneTypeParameterSealedClass<*> = when (name) {
@@ -86,11 +90,11 @@ public object OneTypeParameterSealedClassSealedEnum : SealedEnum<OneTypeParamete
 
     public override fun sealedObjectToEnum(obj: OneTypeParameterSealedClass<*>):
             OneTypeParameterSealedClassEnum = when (obj) {
-        OneTypeParameterSealedClass.FirstObject ->
+        is OneTypeParameterSealedClass.FirstObject ->
                 OneTypeParameterSealedClassEnum.OneTypeParameterSealedClass_FirstObject
-        OneTypeParameterSealedClass.SecondObject ->
+        is OneTypeParameterSealedClass.SecondObject ->
                 OneTypeParameterSealedClassEnum.OneTypeParameterSealedClass_SecondObject
-        OneTypeParameterSealedClass.ThirdObject ->
+        is OneTypeParameterSealedClass.ThirdObject ->
                 OneTypeParameterSealedClassEnum.OneTypeParameterSealedClass_ThirdObject
     }
 
@@ -159,6 +163,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -190,23 +195,26 @@ public object TwoTypeParameterSealedClassSealedEnum : SealedEnum<TwoTypeParamete
         SealedEnumWithEnumProvider<TwoTypeParameterSealedClass<*, *>, TwoTypeParameterSealedClassEnum>,
         EnumForSealedEnumProvider<TwoTypeParameterSealedClass<*, *>, TwoTypeParameterSealedClassEnum>
         {
-    public override val values: List<TwoTypeParameterSealedClass<*, *>> = listOf(
-        TwoTypeParameterSealedClass.FirstObject,
-        TwoTypeParameterSealedClass.SecondObject
-    )
+    public override val values: List<TwoTypeParameterSealedClass<*, *>> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            TwoTypeParameterSealedClass.FirstObject,
+            TwoTypeParameterSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<TwoTypeParameterSealedClassEnum>
         get() = TwoTypeParameterSealedClassEnum::class
 
     public override fun ordinalOf(obj: TwoTypeParameterSealedClass<*, *>): Int = when (obj) {
-        TwoTypeParameterSealedClass.FirstObject -> 0
-        TwoTypeParameterSealedClass.SecondObject -> 1
+        is TwoTypeParameterSealedClass.FirstObject -> 0
+        is TwoTypeParameterSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: TwoTypeParameterSealedClass<*, *>): String = when (obj) {
-        TwoTypeParameterSealedClass.FirstObject -> "TwoTypeParameterSealedClass_FirstObject"
-        TwoTypeParameterSealedClass.SecondObject -> "TwoTypeParameterSealedClass_SecondObject"
+        is TwoTypeParameterSealedClass.FirstObject -> "TwoTypeParameterSealedClass_FirstObject"
+        is TwoTypeParameterSealedClass.SecondObject -> "TwoTypeParameterSealedClass_SecondObject"
     }
 
     public override fun valueOf(name: String): TwoTypeParameterSealedClass<*, *> = when (name) {
@@ -217,9 +225,9 @@ public object TwoTypeParameterSealedClassSealedEnum : SealedEnum<TwoTypeParamete
 
     public override fun sealedObjectToEnum(obj: TwoTypeParameterSealedClass<*, *>):
             TwoTypeParameterSealedClassEnum = when (obj) {
-        TwoTypeParameterSealedClass.FirstObject ->
+        is TwoTypeParameterSealedClass.FirstObject ->
                 TwoTypeParameterSealedClassEnum.TwoTypeParameterSealedClass_FirstObject
-        TwoTypeParameterSealedClass.SecondObject ->
+        is TwoTypeParameterSealedClass.SecondObject ->
                 TwoTypeParameterSealedClassEnum.TwoTypeParameterSealedClass_SecondObject
     }
 
@@ -286,6 +294,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -318,23 +327,27 @@ public object LimitedTypeParameterSealedClassSealedEnum :
         SealedEnumWithEnumProvider<LimitedTypeParameterSealedClass<*, *>, LimitedTypeParameterSealedClassEnum>,
         EnumForSealedEnumProvider<LimitedTypeParameterSealedClass<*, *>, LimitedTypeParameterSealedClassEnum>
         {
-    public override val values: List<LimitedTypeParameterSealedClass<*, *>> = listOf(
-        LimitedTypeParameterSealedClass.FirstObject,
-        LimitedTypeParameterSealedClass.SecondObject
-    )
+    public override val values: List<LimitedTypeParameterSealedClass<*, *>> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            LimitedTypeParameterSealedClass.FirstObject,
+            LimitedTypeParameterSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<LimitedTypeParameterSealedClassEnum>
         get() = LimitedTypeParameterSealedClassEnum::class
 
     public override fun ordinalOf(obj: LimitedTypeParameterSealedClass<*, *>): Int = when (obj) {
-        LimitedTypeParameterSealedClass.FirstObject -> 0
-        LimitedTypeParameterSealedClass.SecondObject -> 1
+        is LimitedTypeParameterSealedClass.FirstObject -> 0
+        is LimitedTypeParameterSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: LimitedTypeParameterSealedClass<*, *>): String = when (obj) {
-        LimitedTypeParameterSealedClass.FirstObject -> "LimitedTypeParameterSealedClass_FirstObject"
-        LimitedTypeParameterSealedClass.SecondObject ->
+        is LimitedTypeParameterSealedClass.FirstObject ->
+                "LimitedTypeParameterSealedClass_FirstObject"
+        is LimitedTypeParameterSealedClass.SecondObject ->
                 "LimitedTypeParameterSealedClass_SecondObject"
     }
 
@@ -347,9 +360,9 @@ public object LimitedTypeParameterSealedClassSealedEnum :
 
     public override fun sealedObjectToEnum(obj: LimitedTypeParameterSealedClass<*, *>):
             LimitedTypeParameterSealedClassEnum = when (obj) {
-        LimitedTypeParameterSealedClass.FirstObject ->
+        is LimitedTypeParameterSealedClass.FirstObject ->
                 LimitedTypeParameterSealedClassEnum.LimitedTypeParameterSealedClass_FirstObject
-        LimitedTypeParameterSealedClass.SecondObject ->
+        is LimitedTypeParameterSealedClass.SecondObject ->
                 LimitedTypeParameterSealedClassEnum.LimitedTypeParameterSealedClass_SecondObject
     }
 
@@ -421,6 +434,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -450,20 +464,23 @@ public val MultipleBoundsSealedClassEnum.sealedObject: MultipleBoundsSealedClass
 public object MultipleBoundsSealedClassSealedEnum : SealedEnum<MultipleBoundsSealedClass<*>>,
         SealedEnumWithEnumProvider<MultipleBoundsSealedClass<*>, MultipleBoundsSealedClassEnum>,
         EnumForSealedEnumProvider<MultipleBoundsSealedClass<*>, MultipleBoundsSealedClassEnum> {
-    public override val values: List<MultipleBoundsSealedClass<*>> = listOf(
-        MultipleBoundsSealedClass.FirstObject
-    )
+    public override val values: List<MultipleBoundsSealedClass<*>> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            MultipleBoundsSealedClass.FirstObject
+        )
+    }
 
 
     public override val enumClass: KClass<MultipleBoundsSealedClassEnum>
         get() = MultipleBoundsSealedClassEnum::class
 
     public override fun ordinalOf(obj: MultipleBoundsSealedClass<*>): Int = when (obj) {
-        MultipleBoundsSealedClass.FirstObject -> 0
+        is MultipleBoundsSealedClass.FirstObject -> 0
     }
 
     public override fun nameOf(obj: MultipleBoundsSealedClass<*>): String = when (obj) {
-        MultipleBoundsSealedClass.FirstObject -> "MultipleBoundsSealedClass_FirstObject"
+        is MultipleBoundsSealedClass.FirstObject -> "MultipleBoundsSealedClass_FirstObject"
     }
 
     public override fun valueOf(name: String): MultipleBoundsSealedClass<*> = when (name) {
@@ -473,7 +490,7 @@ public object MultipleBoundsSealedClassSealedEnum : SealedEnum<MultipleBoundsSea
 
     public override fun sealedObjectToEnum(obj: MultipleBoundsSealedClass<*>):
             MultipleBoundsSealedClassEnum = when (obj) {
-        MultipleBoundsSealedClass.FirstObject ->
+        is MultipleBoundsSealedClass.FirstObject ->
                 MultipleBoundsSealedClassEnum.MultipleBoundsSealedClass_FirstObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithAbstractBaseClasses.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithAbstractBaseClasses.kt
@@ -29,6 +29,7 @@ import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Any
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -61,7 +62,10 @@ public object SealedEnumWithAbstractBaseClassesSealedEnum :
         SealedEnumWithEnumProvider<SealedEnumWithAbstractBaseClasses, SealedEnumWithAbstractBaseClassesEnum>,
         EnumForSealedEnumProvider<SealedEnumWithAbstractBaseClasses, SealedEnumWithAbstractBaseClassesEnum>
         {
-    public override val values: List<SealedEnumWithAbstractBaseClasses> = emptyList()
+    public override val values: List<SealedEnumWithAbstractBaseClasses> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        emptyList()
+    }
 
 
     public override val enumClass: KClass<SealedEnumWithAbstractBaseClassesEnum>
@@ -141,6 +145,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -175,8 +180,10 @@ public object SealedEnumWithAbstractBaseClassesCovariantTypeSealedEnum :
         SealedEnumWithEnumProvider<SealedEnumWithAbstractBaseClassesCovariantType<*>, SealedEnumWithAbstractBaseClassesCovariantTypeEnum>,
         EnumForSealedEnumProvider<SealedEnumWithAbstractBaseClassesCovariantType<*>, SealedEnumWithAbstractBaseClassesCovariantTypeEnum>
         {
-    public override val values: List<SealedEnumWithAbstractBaseClassesCovariantType<*>> =
-            emptyList()
+    public override val values: List<SealedEnumWithAbstractBaseClassesCovariantType<*>> by lazy(mode
+            = LazyThreadSafetyMode.PUBLICATION) {
+        emptyList()
+    }
 
 
     public override val enumClass: KClass<SealedEnumWithAbstractBaseClassesCovariantTypeEnum>

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithInterfaces.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/generics/SealedEnumWithInterfaces.kt
@@ -24,6 +24,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -54,7 +55,10 @@ public object EmptySealedClassWithInterfaceSealedEnum : SealedEnum<EmptySealedCl
         SealedEnumWithEnumProvider<EmptySealedClassWithInterface, EmptySealedClassWithInterfaceEnum>,
         EnumForSealedEnumProvider<EmptySealedClassWithInterface, EmptySealedClassWithInterfaceEnum>
         {
-    public override val values: List<EmptySealedClassWithInterface> = emptyList()
+    public override val values: List<EmptySealedClassWithInterface> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        emptyList()
+    }
 
 
     public override val enumClass: KClass<EmptySealedClassWithInterfaceEnum>
@@ -129,6 +133,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -162,20 +167,23 @@ public object OneObjectSealedClassWithInterfaceSealedEnum :
         SealedEnumWithEnumProvider<OneObjectSealedClassWithInterface, OneObjectSealedClassWithInterfaceEnum>,
         EnumForSealedEnumProvider<OneObjectSealedClassWithInterface, OneObjectSealedClassWithInterfaceEnum>
         {
-    public override val values: List<OneObjectSealedClassWithInterface> = listOf(
-        OneObjectSealedClassWithInterface.FirstObject
-    )
+    public override val values: List<OneObjectSealedClassWithInterface> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            OneObjectSealedClassWithInterface.FirstObject
+        )
+    }
 
 
     public override val enumClass: KClass<OneObjectSealedClassWithInterfaceEnum>
         get() = OneObjectSealedClassWithInterfaceEnum::class
 
     public override fun ordinalOf(obj: OneObjectSealedClassWithInterface): Int = when (obj) {
-        OneObjectSealedClassWithInterface.FirstObject -> 0
+        is OneObjectSealedClassWithInterface.FirstObject -> 0
     }
 
     public override fun nameOf(obj: OneObjectSealedClassWithInterface): String = when (obj) {
-        OneObjectSealedClassWithInterface.FirstObject ->
+        is OneObjectSealedClassWithInterface.FirstObject ->
                 "OneObjectSealedClassWithInterface_FirstObject"
     }
 
@@ -187,7 +195,7 @@ public object OneObjectSealedClassWithInterfaceSealedEnum :
 
     public override fun sealedObjectToEnum(obj: OneObjectSealedClassWithInterface):
             OneObjectSealedClassWithInterfaceEnum = when (obj) {
-        OneObjectSealedClassWithInterface.FirstObject ->
+        is OneObjectSealedClassWithInterface.FirstObject ->
                 OneObjectSealedClassWithInterfaceEnum.OneObjectSealedClassWithInterface_FirstObject
     }
 
@@ -253,6 +261,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -289,11 +298,13 @@ public object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
         SealedEnumWithEnumProvider<TwoObjectSealedClassWithGenericInterface<TestInterface>, TwoObjectSealedClassWithGenericInterfaceEnum>,
         EnumForSealedEnumProvider<TwoObjectSealedClassWithGenericInterface<TestInterface>, TwoObjectSealedClassWithGenericInterfaceEnum>
         {
-    public override val values: List<TwoObjectSealedClassWithGenericInterface<TestInterface>> =
-            listOf(
-        TwoObjectSealedClassWithGenericInterface.FirstObject,
-        TwoObjectSealedClassWithGenericInterface.SecondObject
-    )
+    public override val values: List<TwoObjectSealedClassWithGenericInterface<TestInterface>> by
+            lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            TwoObjectSealedClassWithGenericInterface.FirstObject,
+            TwoObjectSealedClassWithGenericInterface.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<TwoObjectSealedClassWithGenericInterfaceEnum>
@@ -301,15 +312,15 @@ public object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
 
     public override fun ordinalOf(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>): Int
             = when (obj) {
-        TwoObjectSealedClassWithGenericInterface.FirstObject -> 0
-        TwoObjectSealedClassWithGenericInterface.SecondObject -> 1
+        is TwoObjectSealedClassWithGenericInterface.FirstObject -> 0
+        is TwoObjectSealedClassWithGenericInterface.SecondObject -> 1
     }
 
     public override fun nameOf(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>): String
             = when (obj) {
-        TwoObjectSealedClassWithGenericInterface.FirstObject ->
+        is TwoObjectSealedClassWithGenericInterface.FirstObject ->
                 "TwoObjectSealedClassWithGenericInterface_FirstObject"
-        TwoObjectSealedClassWithGenericInterface.SecondObject ->
+        is TwoObjectSealedClassWithGenericInterface.SecondObject ->
                 "TwoObjectSealedClassWithGenericInterface_SecondObject"
     }
 
@@ -325,9 +336,9 @@ public object TwoObjectSealedClassWithGenericInterfaceSealedEnum :
     public override
             fun sealedObjectToEnum(obj: TwoObjectSealedClassWithGenericInterface<TestInterface>):
             TwoObjectSealedClassWithGenericInterfaceEnum = when (obj) {
-        TwoObjectSealedClassWithGenericInterface.FirstObject ->
+        is TwoObjectSealedClassWithGenericInterface.FirstObject ->
                 TwoObjectSealedClassWithGenericInterfaceEnum.TwoObjectSealedClassWithGenericInterface_FirstObject
-        TwoObjectSealedClassWithGenericInterface.SecondObject ->
+        is TwoObjectSealedClassWithGenericInterface.SecondObject ->
                 TwoObjectSealedClassWithGenericInterfaceEnum.TwoObjectSealedClassWithGenericInterface_SecondObject
     }
 
@@ -401,6 +412,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -433,20 +445,24 @@ public object SealedClassWithGetterInterfaceSealedEnum : SealedEnum<SealedClassW
         SealedEnumWithEnumProvider<SealedClassWithGetterInterface, SealedClassWithGetterInterfaceEnum>,
         EnumForSealedEnumProvider<SealedClassWithGetterInterface, SealedClassWithGetterInterfaceEnum>
         {
-    public override val values: List<SealedClassWithGetterInterface> = listOf(
-        SealedClassWithGetterInterface.FirstObject
-    )
+    public override val values: List<SealedClassWithGetterInterface> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SealedClassWithGetterInterface.FirstObject
+        )
+    }
 
 
     public override val enumClass: KClass<SealedClassWithGetterInterfaceEnum>
         get() = SealedClassWithGetterInterfaceEnum::class
 
     public override fun ordinalOf(obj: SealedClassWithGetterInterface): Int = when (obj) {
-        SealedClassWithGetterInterface.FirstObject -> 0
+        is SealedClassWithGetterInterface.FirstObject -> 0
     }
 
     public override fun nameOf(obj: SealedClassWithGetterInterface): String = when (obj) {
-        SealedClassWithGetterInterface.FirstObject -> "SealedClassWithGetterInterface_FirstObject"
+        is SealedClassWithGetterInterface.FirstObject ->
+                "SealedClassWithGetterInterface_FirstObject"
     }
 
     public override fun valueOf(name: String): SealedClassWithGetterInterface = when (name) {
@@ -456,7 +472,7 @@ public object SealedClassWithGetterInterfaceSealedEnum : SealedEnum<SealedClassW
 
     public override fun sealedObjectToEnum(obj: SealedClassWithGetterInterface):
             SealedClassWithGetterInterfaceEnum = when (obj) {
-        SealedClassWithGetterInterface.FirstObject ->
+        is SealedClassWithGetterInterface.FirstObject ->
                 SealedClassWithGetterInterfaceEnum.SealedClassWithGetterInterface_FirstObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedClassHierarchy.kt
@@ -27,6 +27,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -56,20 +57,23 @@ public val FirstClassHierarchy_AEnum.sealedObject: FirstClassHierarchy.A
 public object FirstClassHierarchy_ASealedEnum : SealedEnum<FirstClassHierarchy.A>,
         SealedEnumWithEnumProvider<FirstClassHierarchy.A, FirstClassHierarchy_AEnum>,
         EnumForSealedEnumProvider<FirstClassHierarchy.A, FirstClassHierarchy_AEnum> {
-    public override val values: List<FirstClassHierarchy.A> = listOf(
-        FirstClassHierarchy.A.B.C
-    )
+    public override val values: List<FirstClassHierarchy.A> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            FirstClassHierarchy.A.B.C
+        )
+    }
 
 
     public override val enumClass: KClass<FirstClassHierarchy_AEnum>
         get() = FirstClassHierarchy_AEnum::class
 
     public override fun ordinalOf(obj: FirstClassHierarchy.A): Int = when (obj) {
-        FirstClassHierarchy.A.B.C -> 0
+        is FirstClassHierarchy.A.B.C -> 0
     }
 
     public override fun nameOf(obj: FirstClassHierarchy.A): String = when (obj) {
-        FirstClassHierarchy.A.B.C -> "FirstClassHierarchy_A_B_C"
+        is FirstClassHierarchy.A.B.C -> "FirstClassHierarchy_A_B_C"
     }
 
     public override fun valueOf(name: String): FirstClassHierarchy.A = when (name) {
@@ -79,7 +83,7 @@ public object FirstClassHierarchy_ASealedEnum : SealedEnum<FirstClassHierarchy.A
 
     public override fun sealedObjectToEnum(obj: FirstClassHierarchy.A): FirstClassHierarchy_AEnum =
             when (obj) {
-        FirstClassHierarchy.A.B.C -> FirstClassHierarchy_AEnum.FirstClassHierarchy_A_B_C
+        is FirstClassHierarchy.A.B.C -> FirstClassHierarchy_AEnum.FirstClassHierarchy_A_B_C
     }
 
     public override fun enumToSealedObject(`enum`: FirstClassHierarchy_AEnum): FirstClassHierarchy.A
@@ -131,6 +135,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -160,20 +165,23 @@ public val FirstClassHierarchy_A_BEnum.sealedObject: FirstClassHierarchy.A.B
 public object FirstClassHierarchy_A_BSealedEnum : SealedEnum<FirstClassHierarchy.A.B>,
         SealedEnumWithEnumProvider<FirstClassHierarchy.A.B, FirstClassHierarchy_A_BEnum>,
         EnumForSealedEnumProvider<FirstClassHierarchy.A.B, FirstClassHierarchy_A_BEnum> {
-    public override val values: List<FirstClassHierarchy.A.B> = listOf(
-        FirstClassHierarchy.A.B.C
-    )
+    public override val values: List<FirstClassHierarchy.A.B> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            FirstClassHierarchy.A.B.C
+        )
+    }
 
 
     public override val enumClass: KClass<FirstClassHierarchy_A_BEnum>
         get() = FirstClassHierarchy_A_BEnum::class
 
     public override fun ordinalOf(obj: FirstClassHierarchy.A.B): Int = when (obj) {
-        FirstClassHierarchy.A.B.C -> 0
+        is FirstClassHierarchy.A.B.C -> 0
     }
 
     public override fun nameOf(obj: FirstClassHierarchy.A.B): String = when (obj) {
-        FirstClassHierarchy.A.B.C -> "FirstClassHierarchy_A_B_C"
+        is FirstClassHierarchy.A.B.C -> "FirstClassHierarchy_A_B_C"
     }
 
     public override fun valueOf(name: String): FirstClassHierarchy.A.B = when (name) {
@@ -183,7 +191,7 @@ public object FirstClassHierarchy_A_BSealedEnum : SealedEnum<FirstClassHierarchy
 
     public override fun sealedObjectToEnum(obj: FirstClassHierarchy.A.B):
             FirstClassHierarchy_A_BEnum = when (obj) {
-        FirstClassHierarchy.A.B.C -> FirstClassHierarchy_A_BEnum.FirstClassHierarchy_A_B_C
+        is FirstClassHierarchy.A.B.C -> FirstClassHierarchy_A_BEnum.FirstClassHierarchy_A_B_C
     }
 
     public override fun enumToSealedObject(`enum`: FirstClassHierarchy_A_BEnum):
@@ -278,6 +286,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -285,35 +294,38 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z]
  */
 public object SecondClassHierarchy_ZSealedEnum : SealedEnum<SecondClassHierarchy.Z> {
-    public override val values: List<SecondClassHierarchy.Z> = listOf(
-        SecondClassHierarchy.Z.Y,
-        SecondClassHierarchy.Z.X.W,
-        SecondClassHierarchy.Z.X.V,
-        SecondClassHierarchy.Z.X.U.T,
-        SecondClassHierarchy.Z.X.S.R,
-        SecondClassHierarchy.Z.Q.P,
-        SecondClassHierarchy.Z.O
-    )
+    public override val values: List<SecondClassHierarchy.Z> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondClassHierarchy.Z.Y,
+            SecondClassHierarchy.Z.X.W,
+            SecondClassHierarchy.Z.X.V,
+            SecondClassHierarchy.Z.X.U.T,
+            SecondClassHierarchy.Z.X.S.R,
+            SecondClassHierarchy.Z.Q.P,
+            SecondClassHierarchy.Z.O
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondClassHierarchy.Z): Int = when (obj) {
-        SecondClassHierarchy.Z.Y -> 0
-        SecondClassHierarchy.Z.X.W -> 1
-        SecondClassHierarchy.Z.X.V -> 2
-        SecondClassHierarchy.Z.X.U.T -> 3
-        SecondClassHierarchy.Z.X.S.R -> 4
-        SecondClassHierarchy.Z.Q.P -> 5
-        SecondClassHierarchy.Z.O -> 6
+        is SecondClassHierarchy.Z.Y -> 0
+        is SecondClassHierarchy.Z.X.W -> 1
+        is SecondClassHierarchy.Z.X.V -> 2
+        is SecondClassHierarchy.Z.X.U.T -> 3
+        is SecondClassHierarchy.Z.X.S.R -> 4
+        is SecondClassHierarchy.Z.Q.P -> 5
+        is SecondClassHierarchy.Z.O -> 6
     }
 
     public override fun nameOf(obj: SecondClassHierarchy.Z): String = when (obj) {
-        SecondClassHierarchy.Z.Y -> "SecondClassHierarchy_Z_Y"
-        SecondClassHierarchy.Z.X.W -> "SecondClassHierarchy_Z_X_W"
-        SecondClassHierarchy.Z.X.V -> "SecondClassHierarchy_Z_X_V"
-        SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
-        SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
-        SecondClassHierarchy.Z.Q.P -> "SecondClassHierarchy_Z_Q_P"
-        SecondClassHierarchy.Z.O -> "SecondClassHierarchy_Z_O"
+        is SecondClassHierarchy.Z.Y -> "SecondClassHierarchy_Z_Y"
+        is SecondClassHierarchy.Z.X.W -> "SecondClassHierarchy_Z_X_W"
+        is SecondClassHierarchy.Z.X.V -> "SecondClassHierarchy_Z_X_V"
+        is SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
+        is SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
+        is SecondClassHierarchy.Z.Q.P -> "SecondClassHierarchy_Z_Q_P"
+        is SecondClassHierarchy.Z.O -> "SecondClassHierarchy_Z_O"
     }
 
     public override fun valueOf(name: String): SecondClassHierarchy.Z = when (name) {
@@ -369,6 +381,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -376,26 +389,29 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X]
  */
 public object SecondClassHierarchy_Z_XSealedEnum : SealedEnum<SecondClassHierarchy.Z.X> {
-    public override val values: List<SecondClassHierarchy.Z.X> = listOf(
-        SecondClassHierarchy.Z.X.W,
-        SecondClassHierarchy.Z.X.V,
-        SecondClassHierarchy.Z.X.U.T,
-        SecondClassHierarchy.Z.X.S.R
-    )
+    public override val values: List<SecondClassHierarchy.Z.X> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondClassHierarchy.Z.X.W,
+            SecondClassHierarchy.Z.X.V,
+            SecondClassHierarchy.Z.X.U.T,
+            SecondClassHierarchy.Z.X.S.R
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondClassHierarchy.Z.X): Int = when (obj) {
-        SecondClassHierarchy.Z.X.W -> 0
-        SecondClassHierarchy.Z.X.V -> 1
-        SecondClassHierarchy.Z.X.U.T -> 2
-        SecondClassHierarchy.Z.X.S.R -> 3
+        is SecondClassHierarchy.Z.X.W -> 0
+        is SecondClassHierarchy.Z.X.V -> 1
+        is SecondClassHierarchy.Z.X.U.T -> 2
+        is SecondClassHierarchy.Z.X.S.R -> 3
     }
 
     public override fun nameOf(obj: SecondClassHierarchy.Z.X): String = when (obj) {
-        SecondClassHierarchy.Z.X.W -> "SecondClassHierarchy_Z_X_W"
-        SecondClassHierarchy.Z.X.V -> "SecondClassHierarchy_Z_X_V"
-        SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
-        SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
+        is SecondClassHierarchy.Z.X.W -> "SecondClassHierarchy_Z_X_W"
+        is SecondClassHierarchy.Z.X.V -> "SecondClassHierarchy_Z_X_V"
+        is SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
+        is SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
     }
 
     public override fun valueOf(name: String): SecondClassHierarchy.Z.X = when (name) {
@@ -448,6 +464,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -455,17 +472,20 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X.U]
  */
 public object SecondClassHierarchy_Z_X_USealedEnum : SealedEnum<SecondClassHierarchy.Z.X.U> {
-    public override val values: List<SecondClassHierarchy.Z.X.U> = listOf(
-        SecondClassHierarchy.Z.X.U.T
-    )
+    public override val values: List<SecondClassHierarchy.Z.X.U> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondClassHierarchy.Z.X.U.T
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondClassHierarchy.Z.X.U): Int = when (obj) {
-        SecondClassHierarchy.Z.X.U.T -> 0
+        is SecondClassHierarchy.Z.X.U.T -> 0
     }
 
     public override fun nameOf(obj: SecondClassHierarchy.Z.X.U): String = when (obj) {
-        SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
+        is SecondClassHierarchy.Z.X.U.T -> "SecondClassHierarchy_Z_X_U_T"
     }
 
     public override fun valueOf(name: String): SecondClassHierarchy.Z.X.U = when (name) {
@@ -515,6 +535,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -522,17 +543,20 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.X.S]
  */
 public object SecondClassHierarchy_Z_X_SSealedEnum : SealedEnum<SecondClassHierarchy.Z.X.S> {
-    public override val values: List<SecondClassHierarchy.Z.X.S> = listOf(
-        SecondClassHierarchy.Z.X.S.R
-    )
+    public override val values: List<SecondClassHierarchy.Z.X.S> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondClassHierarchy.Z.X.S.R
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondClassHierarchy.Z.X.S): Int = when (obj) {
-        SecondClassHierarchy.Z.X.S.R -> 0
+        is SecondClassHierarchy.Z.X.S.R -> 0
     }
 
     public override fun nameOf(obj: SecondClassHierarchy.Z.X.S): String = when (obj) {
-        SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
+        is SecondClassHierarchy.Z.X.S.R -> "SecondClassHierarchy_Z_X_S_R"
     }
 
     public override fun valueOf(name: String): SecondClassHierarchy.Z.X.S = when (name) {
@@ -582,6 +606,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -589,17 +614,20 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class [SecondClassHierarchy.Z.Q]
  */
 public object SecondClassHierarchy_Z_QSealedEnum : SealedEnum<SecondClassHierarchy.Z.Q> {
-    public override val values: List<SecondClassHierarchy.Z.Q> = listOf(
-        SecondClassHierarchy.Z.Q.P
-    )
+    public override val values: List<SecondClassHierarchy.Z.Q> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondClassHierarchy.Z.Q.P
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondClassHierarchy.Z.Q): Int = when (obj) {
-        SecondClassHierarchy.Z.Q.P -> 0
+        is SecondClassHierarchy.Z.Q.P -> 0
     }
 
     public override fun nameOf(obj: SecondClassHierarchy.Z.Q): String = when (obj) {
-        SecondClassHierarchy.Z.Q.P -> "SecondClassHierarchy_Z_Q_P"
+        is SecondClassHierarchy.Z.Q.P -> "SecondClassHierarchy_Z_Q_P"
     }
 
     public override fun valueOf(name: String): SecondClassHierarchy.Z.Q = when (name) {

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedInterfaceHierarchy.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/hierarchy/SealedInterfaceHierarchy.kt
@@ -27,6 +27,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -56,20 +57,23 @@ public val FirstInterfaceHierarchy_AEnum.sealedObject: FirstInterfaceHierarchy.A
 public object FirstInterfaceHierarchy_ASealedEnum : SealedEnum<FirstInterfaceHierarchy.A>,
         SealedEnumWithEnumProvider<FirstInterfaceHierarchy.A, FirstInterfaceHierarchy_AEnum>,
         EnumForSealedEnumProvider<FirstInterfaceHierarchy.A, FirstInterfaceHierarchy_AEnum> {
-    public override val values: List<FirstInterfaceHierarchy.A> = listOf(
-        FirstInterfaceHierarchy.A.B.C
-    )
+    public override val values: List<FirstInterfaceHierarchy.A> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            FirstInterfaceHierarchy.A.B.C
+        )
+    }
 
 
     public override val enumClass: KClass<FirstInterfaceHierarchy_AEnum>
         get() = FirstInterfaceHierarchy_AEnum::class
 
     public override fun ordinalOf(obj: FirstInterfaceHierarchy.A): Int = when (obj) {
-        FirstInterfaceHierarchy.A.B.C -> 0
+        is FirstInterfaceHierarchy.A.B.C -> 0
     }
 
     public override fun nameOf(obj: FirstInterfaceHierarchy.A): String = when (obj) {
-        FirstInterfaceHierarchy.A.B.C -> "FirstInterfaceHierarchy_A_B_C"
+        is FirstInterfaceHierarchy.A.B.C -> "FirstInterfaceHierarchy_A_B_C"
     }
 
     public override fun valueOf(name: String): FirstInterfaceHierarchy.A = when (name) {
@@ -79,7 +83,8 @@ public object FirstInterfaceHierarchy_ASealedEnum : SealedEnum<FirstInterfaceHie
 
     public override fun sealedObjectToEnum(obj: FirstInterfaceHierarchy.A):
             FirstInterfaceHierarchy_AEnum = when (obj) {
-        FirstInterfaceHierarchy.A.B.C -> FirstInterfaceHierarchy_AEnum.FirstInterfaceHierarchy_A_B_C
+        is FirstInterfaceHierarchy.A.B.C ->
+                FirstInterfaceHierarchy_AEnum.FirstInterfaceHierarchy_A_B_C
     }
 
     public override fun enumToSealedObject(`enum`: FirstInterfaceHierarchy_AEnum):
@@ -131,6 +136,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -160,20 +166,23 @@ public val FirstInterfaceHierarchy_A_BEnum.sealedObject: FirstInterfaceHierarchy
 public object FirstInterfaceHierarchy_A_BSealedEnum : SealedEnum<FirstInterfaceHierarchy.A.B>,
         SealedEnumWithEnumProvider<FirstInterfaceHierarchy.A.B, FirstInterfaceHierarchy_A_BEnum>,
         EnumForSealedEnumProvider<FirstInterfaceHierarchy.A.B, FirstInterfaceHierarchy_A_BEnum> {
-    public override val values: List<FirstInterfaceHierarchy.A.B> = listOf(
-        FirstInterfaceHierarchy.A.B.C
-    )
+    public override val values: List<FirstInterfaceHierarchy.A.B> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            FirstInterfaceHierarchy.A.B.C
+        )
+    }
 
 
     public override val enumClass: KClass<FirstInterfaceHierarchy_A_BEnum>
         get() = FirstInterfaceHierarchy_A_BEnum::class
 
     public override fun ordinalOf(obj: FirstInterfaceHierarchy.A.B): Int = when (obj) {
-        FirstInterfaceHierarchy.A.B.C -> 0
+        is FirstInterfaceHierarchy.A.B.C -> 0
     }
 
     public override fun nameOf(obj: FirstInterfaceHierarchy.A.B): String = when (obj) {
-        FirstInterfaceHierarchy.A.B.C -> "FirstInterfaceHierarchy_A_B_C"
+        is FirstInterfaceHierarchy.A.B.C -> "FirstInterfaceHierarchy_A_B_C"
     }
 
     public override fun valueOf(name: String): FirstInterfaceHierarchy.A.B = when (name) {
@@ -183,7 +192,7 @@ public object FirstInterfaceHierarchy_A_BSealedEnum : SealedEnum<FirstInterfaceH
 
     public override fun sealedObjectToEnum(obj: FirstInterfaceHierarchy.A.B):
             FirstInterfaceHierarchy_A_BEnum = when (obj) {
-        FirstInterfaceHierarchy.A.B.C ->
+        is FirstInterfaceHierarchy.A.B.C ->
                 FirstInterfaceHierarchy_A_BEnum.FirstInterfaceHierarchy_A_B_C
     }
 
@@ -280,6 +289,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -287,35 +297,38 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class [SecondInterfaceHierarchy.A]
  */
 public object SecondInterfaceHierarchy_ASealedEnum : SealedEnum<SecondInterfaceHierarchy.A> {
-    public override val values: List<SecondInterfaceHierarchy.A> = listOf(
-        SecondInterfaceHierarchy.A.B,
-        SecondInterfaceHierarchy.A.C.D,
-        SecondInterfaceHierarchy.A.C.E,
-        SecondInterfaceHierarchy.A.C.F.G,
-        SecondInterfaceHierarchy.A.C.H.I,
-        SecondInterfaceHierarchy.A.J.K,
-        SecondInterfaceHierarchy.A.L
-    )
+    public override val values: List<SecondInterfaceHierarchy.A> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondInterfaceHierarchy.A.B,
+            SecondInterfaceHierarchy.A.C.D,
+            SecondInterfaceHierarchy.A.C.E,
+            SecondInterfaceHierarchy.A.C.F.G,
+            SecondInterfaceHierarchy.A.C.H.I,
+            SecondInterfaceHierarchy.A.J.K,
+            SecondInterfaceHierarchy.A.L
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondInterfaceHierarchy.A): Int = when (obj) {
-        SecondInterfaceHierarchy.A.B -> 0
-        SecondInterfaceHierarchy.A.C.D -> 1
-        SecondInterfaceHierarchy.A.C.E -> 2
-        SecondInterfaceHierarchy.A.C.F.G -> 3
-        SecondInterfaceHierarchy.A.C.H.I -> 4
-        SecondInterfaceHierarchy.A.J.K -> 5
-        SecondInterfaceHierarchy.A.L -> 6
+        is SecondInterfaceHierarchy.A.B -> 0
+        is SecondInterfaceHierarchy.A.C.D -> 1
+        is SecondInterfaceHierarchy.A.C.E -> 2
+        is SecondInterfaceHierarchy.A.C.F.G -> 3
+        is SecondInterfaceHierarchy.A.C.H.I -> 4
+        is SecondInterfaceHierarchy.A.J.K -> 5
+        is SecondInterfaceHierarchy.A.L -> 6
     }
 
     public override fun nameOf(obj: SecondInterfaceHierarchy.A): String = when (obj) {
-        SecondInterfaceHierarchy.A.B -> "SecondInterfaceHierarchy_A_B"
-        SecondInterfaceHierarchy.A.C.D -> "SecondInterfaceHierarchy_A_C_D"
-        SecondInterfaceHierarchy.A.C.E -> "SecondInterfaceHierarchy_A_C_E"
-        SecondInterfaceHierarchy.A.C.F.G -> "SecondInterfaceHierarchy_A_C_F_G"
-        SecondInterfaceHierarchy.A.C.H.I -> "SecondInterfaceHierarchy_A_C_H_I"
-        SecondInterfaceHierarchy.A.J.K -> "SecondInterfaceHierarchy_A_J_K"
-        SecondInterfaceHierarchy.A.L -> "SecondInterfaceHierarchy_A_L"
+        is SecondInterfaceHierarchy.A.B -> "SecondInterfaceHierarchy_A_B"
+        is SecondInterfaceHierarchy.A.C.D -> "SecondInterfaceHierarchy_A_C_D"
+        is SecondInterfaceHierarchy.A.C.E -> "SecondInterfaceHierarchy_A_C_E"
+        is SecondInterfaceHierarchy.A.C.F.G -> "SecondInterfaceHierarchy_A_C_F_G"
+        is SecondInterfaceHierarchy.A.C.H.I -> "SecondInterfaceHierarchy_A_C_H_I"
+        is SecondInterfaceHierarchy.A.J.K -> "SecondInterfaceHierarchy_A_J_K"
+        is SecondInterfaceHierarchy.A.L -> "SecondInterfaceHierarchy_A_L"
     }
 
     public override fun valueOf(name: String): SecondInterfaceHierarchy.A = when (name) {
@@ -371,6 +384,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -378,26 +392,29 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class [SecondInterfaceHierarchy.A.C]
  */
 public object SecondInterfaceHierarchy_A_CSealedEnum : SealedEnum<SecondInterfaceHierarchy.A.C> {
-    public override val values: List<SecondInterfaceHierarchy.A.C> = listOf(
-        SecondInterfaceHierarchy.A.C.D,
-        SecondInterfaceHierarchy.A.C.E,
-        SecondInterfaceHierarchy.A.C.F.G,
-        SecondInterfaceHierarchy.A.C.H.I
-    )
+    public override val values: List<SecondInterfaceHierarchy.A.C> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondInterfaceHierarchy.A.C.D,
+            SecondInterfaceHierarchy.A.C.E,
+            SecondInterfaceHierarchy.A.C.F.G,
+            SecondInterfaceHierarchy.A.C.H.I
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondInterfaceHierarchy.A.C): Int = when (obj) {
-        SecondInterfaceHierarchy.A.C.D -> 0
-        SecondInterfaceHierarchy.A.C.E -> 1
-        SecondInterfaceHierarchy.A.C.F.G -> 2
-        SecondInterfaceHierarchy.A.C.H.I -> 3
+        is SecondInterfaceHierarchy.A.C.D -> 0
+        is SecondInterfaceHierarchy.A.C.E -> 1
+        is SecondInterfaceHierarchy.A.C.F.G -> 2
+        is SecondInterfaceHierarchy.A.C.H.I -> 3
     }
 
     public override fun nameOf(obj: SecondInterfaceHierarchy.A.C): String = when (obj) {
-        SecondInterfaceHierarchy.A.C.D -> "SecondInterfaceHierarchy_A_C_D"
-        SecondInterfaceHierarchy.A.C.E -> "SecondInterfaceHierarchy_A_C_E"
-        SecondInterfaceHierarchy.A.C.F.G -> "SecondInterfaceHierarchy_A_C_F_G"
-        SecondInterfaceHierarchy.A.C.H.I -> "SecondInterfaceHierarchy_A_C_H_I"
+        is SecondInterfaceHierarchy.A.C.D -> "SecondInterfaceHierarchy_A_C_D"
+        is SecondInterfaceHierarchy.A.C.E -> "SecondInterfaceHierarchy_A_C_E"
+        is SecondInterfaceHierarchy.A.C.F.G -> "SecondInterfaceHierarchy_A_C_F_G"
+        is SecondInterfaceHierarchy.A.C.H.I -> "SecondInterfaceHierarchy_A_C_H_I"
     }
 
     public override fun valueOf(name: String): SecondInterfaceHierarchy.A.C = when (name) {
@@ -450,6 +467,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -458,17 +476,20 @@ import kotlin.collections.List
  */
 public object SecondInterfaceHierarchy_A_C_FSealedEnum : SealedEnum<SecondInterfaceHierarchy.A.C.F>
         {
-    public override val values: List<SecondInterfaceHierarchy.A.C.F> = listOf(
-        SecondInterfaceHierarchy.A.C.F.G
-    )
+    public override val values: List<SecondInterfaceHierarchy.A.C.F> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondInterfaceHierarchy.A.C.F.G
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondInterfaceHierarchy.A.C.F): Int = when (obj) {
-        SecondInterfaceHierarchy.A.C.F.G -> 0
+        is SecondInterfaceHierarchy.A.C.F.G -> 0
     }
 
     public override fun nameOf(obj: SecondInterfaceHierarchy.A.C.F): String = when (obj) {
-        SecondInterfaceHierarchy.A.C.F.G -> "SecondInterfaceHierarchy_A_C_F_G"
+        is SecondInterfaceHierarchy.A.C.F.G -> "SecondInterfaceHierarchy_A_C_F_G"
     }
 
     public override fun valueOf(name: String): SecondInterfaceHierarchy.A.C.F = when (name) {
@@ -519,6 +540,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -527,17 +549,20 @@ import kotlin.collections.List
  */
 public object SecondInterfaceHierarchy_A_C_HSealedEnum : SealedEnum<SecondInterfaceHierarchy.A.C.H>
         {
-    public override val values: List<SecondInterfaceHierarchy.A.C.H> = listOf(
-        SecondInterfaceHierarchy.A.C.H.I
-    )
+    public override val values: List<SecondInterfaceHierarchy.A.C.H> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondInterfaceHierarchy.A.C.H.I
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondInterfaceHierarchy.A.C.H): Int = when (obj) {
-        SecondInterfaceHierarchy.A.C.H.I -> 0
+        is SecondInterfaceHierarchy.A.C.H.I -> 0
     }
 
     public override fun nameOf(obj: SecondInterfaceHierarchy.A.C.H): String = when (obj) {
-        SecondInterfaceHierarchy.A.C.H.I -> "SecondInterfaceHierarchy_A_C_H_I"
+        is SecondInterfaceHierarchy.A.C.H.I -> "SecondInterfaceHierarchy_A_C_H_I"
     }
 
     public override fun valueOf(name: String): SecondInterfaceHierarchy.A.C.H = when (name) {
@@ -588,6 +613,7 @@ package com.livefront.sealedenum.compilation.hierarchy
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -595,17 +621,20 @@ import kotlin.collections.List
  * An implementation of [SealedEnum] for the sealed class [SecondInterfaceHierarchy.A.J]
  */
 public object SecondInterfaceHierarchy_A_JSealedEnum : SealedEnum<SecondInterfaceHierarchy.A.J> {
-    public override val values: List<SecondInterfaceHierarchy.A.J> = listOf(
-        SecondInterfaceHierarchy.A.J.K
-    )
+    public override val values: List<SecondInterfaceHierarchy.A.J> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SecondInterfaceHierarchy.A.J.K
+        )
+    }
 
 
     public override fun ordinalOf(obj: SecondInterfaceHierarchy.A.J): Int = when (obj) {
-        SecondInterfaceHierarchy.A.J.K -> 0
+        is SecondInterfaceHierarchy.A.J.K -> 0
     }
 
     public override fun nameOf(obj: SecondInterfaceHierarchy.A.J): String = when (obj) {
-        SecondInterfaceHierarchy.A.J.K -> "SecondInterfaceHierarchy_A_J_K"
+        is SecondInterfaceHierarchy.A.J.K -> "SecondInterfaceHierarchy_A_J_K"
     }
 
     public override fun valueOf(name: String): SecondInterfaceHierarchy.A.J = when (name) {

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/NestedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/NestedClass.kt
@@ -20,6 +20,7 @@ package com.livefront.sealedenum.compilation.location
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -28,21 +29,24 @@ import kotlin.collections.List
  */
 public object OuterClass_InsideOneClassSealedClassSealedEnum :
         SealedEnum<OuterClass.InsideOneClassSealedClass> {
-    public override val values: List<OuterClass.InsideOneClassSealedClass> = listOf(
-        OuterClass.InsideOneClassSealedClass.FirstObject,
-        OuterClass.InsideOneClassSealedClass.SecondObject
-    )
+    public override val values: List<OuterClass.InsideOneClassSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            OuterClass.InsideOneClassSealedClass.FirstObject,
+            OuterClass.InsideOneClassSealedClass.SecondObject
+        )
+    }
 
 
     public override fun ordinalOf(obj: OuterClass.InsideOneClassSealedClass): Int = when (obj) {
-        OuterClass.InsideOneClassSealedClass.FirstObject -> 0
-        OuterClass.InsideOneClassSealedClass.SecondObject -> 1
+        is OuterClass.InsideOneClassSealedClass.FirstObject -> 0
+        is OuterClass.InsideOneClassSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: OuterClass.InsideOneClassSealedClass): String = when (obj) {
-        OuterClass.InsideOneClassSealedClass.FirstObject ->
+        is OuterClass.InsideOneClassSealedClass.FirstObject ->
                 "OuterClass_InsideOneClassSealedClass_FirstObject"
-        OuterClass.InsideOneClassSealedClass.SecondObject ->
+        is OuterClass.InsideOneClassSealedClass.SecondObject ->
                 "OuterClass_InsideOneClassSealedClass_SecondObject"
     }
 
@@ -113,6 +117,7 @@ package com.livefront.sealedenum.compilation.location
 
 import com.livefront.sealedenum.SealedEnum
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 
@@ -122,25 +127,27 @@ import kotlin.collections.List
  */
 public object FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClassSealedEnum :
         SealedEnum<FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass> {
-    public override val values: List<FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass> =
-            listOf(
-        FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject,
-        FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject
-    )
+    public override val values: List<FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass>
+            by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject,
+            FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject
+        )
+    }
 
 
     public override
             fun ordinalOf(obj: FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass): Int =
             when (obj) {
-        FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject -> 0
-        FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject -> 1
+        is FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject -> 0
+        is FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass):
             String = when (obj) {
-        FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject ->
+        is FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.FirstObject ->
                 "FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClass_FirstObject"
-        FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject ->
+        is FirstOuterClass.SecondOuterClass.InsideTwoClassesSealedClass.SecondObject ->
                 "FirstOuterClass_SecondOuterClass_InsideTwoClassesSealedClass_SecondObject"
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/OutsideSealedClass.kt
@@ -18,6 +18,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -47,20 +48,23 @@ public val AlphaOutsideSealedClassEnum.sealedObject: AlphaOutsideSealedClass
 public object AlphaOutsideSealedClassSealedEnum : SealedEnum<AlphaOutsideSealedClass>,
         SealedEnumWithEnumProvider<AlphaOutsideSealedClass, AlphaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<AlphaOutsideSealedClass, AlphaOutsideSealedClassEnum> {
-    public override val values: List<AlphaOutsideSealedClass> = listOf(
-        AlphaFirstObject
-    )
+    public override val values: List<AlphaOutsideSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            AlphaFirstObject
+        )
+    }
 
 
     public override val enumClass: KClass<AlphaOutsideSealedClassEnum>
         get() = AlphaOutsideSealedClassEnum::class
 
     public override fun ordinalOf(obj: AlphaOutsideSealedClass): Int = when (obj) {
-        AlphaFirstObject -> 0
+        is AlphaFirstObject -> 0
     }
 
     public override fun nameOf(obj: AlphaOutsideSealedClass): String = when (obj) {
-        AlphaFirstObject -> "AlphaFirstObject"
+        is AlphaFirstObject -> "AlphaFirstObject"
     }
 
     public override fun valueOf(name: String): AlphaOutsideSealedClass = when (name) {
@@ -70,7 +74,7 @@ public object AlphaOutsideSealedClassSealedEnum : SealedEnum<AlphaOutsideSealedC
 
     public override fun sealedObjectToEnum(obj: AlphaOutsideSealedClass):
             AlphaOutsideSealedClassEnum = when (obj) {
-        AlphaFirstObject -> AlphaOutsideSealedClassEnum.AlphaFirstObject
+        is AlphaFirstObject -> AlphaOutsideSealedClassEnum.AlphaFirstObject
     }
 
     public override fun enumToSealedObject(`enum`: AlphaOutsideSealedClassEnum):
@@ -135,6 +139,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -167,29 +172,32 @@ public val BetaOutsideSealedClassEnum.sealedObject: BetaOutsideSealedClass
 public object BetaOutsideSealedClassSealedEnum : SealedEnum<BetaOutsideSealedClass>,
         SealedEnumWithEnumProvider<BetaOutsideSealedClass, BetaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<BetaOutsideSealedClass, BetaOutsideSealedClassEnum> {
-    public override val values: List<BetaOutsideSealedClass> = listOf(
-        BetaFirstObject,
-        BetaFourthObject,
-        BetaSecondObject,
-        BetaThirdObject
-    )
+    public override val values: List<BetaOutsideSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            BetaFirstObject,
+            BetaFourthObject,
+            BetaSecondObject,
+            BetaThirdObject
+        )
+    }
 
 
     public override val enumClass: KClass<BetaOutsideSealedClassEnum>
         get() = BetaOutsideSealedClassEnum::class
 
     public override fun ordinalOf(obj: BetaOutsideSealedClass): Int = when (obj) {
-        BetaFirstObject -> 0
-        BetaFourthObject -> 1
-        BetaSecondObject -> 2
-        BetaThirdObject -> 3
+        is BetaFirstObject -> 0
+        is BetaFourthObject -> 1
+        is BetaSecondObject -> 2
+        is BetaThirdObject -> 3
     }
 
     public override fun nameOf(obj: BetaOutsideSealedClass): String = when (obj) {
-        BetaFirstObject -> "BetaFirstObject"
-        BetaFourthObject -> "BetaFourthObject"
-        BetaSecondObject -> "BetaSecondObject"
-        BetaThirdObject -> "BetaThirdObject"
+        is BetaFirstObject -> "BetaFirstObject"
+        is BetaFourthObject -> "BetaFourthObject"
+        is BetaSecondObject -> "BetaSecondObject"
+        is BetaThirdObject -> "BetaThirdObject"
     }
 
     public override fun valueOf(name: String): BetaOutsideSealedClass = when (name) {
@@ -202,10 +210,10 @@ public object BetaOutsideSealedClassSealedEnum : SealedEnum<BetaOutsideSealedCla
 
     public override fun sealedObjectToEnum(obj: BetaOutsideSealedClass): BetaOutsideSealedClassEnum
             = when (obj) {
-        BetaFirstObject -> BetaOutsideSealedClassEnum.BetaFirstObject
-        BetaFourthObject -> BetaOutsideSealedClassEnum.BetaFourthObject
-        BetaSecondObject -> BetaOutsideSealedClassEnum.BetaSecondObject
-        BetaThirdObject -> BetaOutsideSealedClassEnum.BetaThirdObject
+        is BetaFirstObject -> BetaOutsideSealedClassEnum.BetaFirstObject
+        is BetaFourthObject -> BetaOutsideSealedClassEnum.BetaFourthObject
+        is BetaSecondObject -> BetaOutsideSealedClassEnum.BetaSecondObject
+        is BetaThirdObject -> BetaOutsideSealedClassEnum.BetaThirdObject
     }
 
     public override fun enumToSealedObject(`enum`: BetaOutsideSealedClassEnum):
@@ -274,6 +282,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -306,29 +315,32 @@ public val GammaOutsideSealedClassEnum.sealedObject: GammaOutsideSealedClass
 public object GammaOutsideSealedClassSealedEnum : SealedEnum<GammaOutsideSealedClass>,
         SealedEnumWithEnumProvider<GammaOutsideSealedClass, GammaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<GammaOutsideSealedClass, GammaOutsideSealedClassEnum> {
-    public override val values: List<GammaOutsideSealedClass> = listOf(
-        GammaOutsideSealedClass.GammaSecondObject,
-        GammaFirstObject,
-        GammaFourthObject,
-        GammaThirdObject
-    )
+    public override val values: List<GammaOutsideSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            GammaOutsideSealedClass.GammaSecondObject,
+            GammaFirstObject,
+            GammaFourthObject,
+            GammaThirdObject
+        )
+    }
 
 
     public override val enumClass: KClass<GammaOutsideSealedClassEnum>
         get() = GammaOutsideSealedClassEnum::class
 
     public override fun ordinalOf(obj: GammaOutsideSealedClass): Int = when (obj) {
-        GammaOutsideSealedClass.GammaSecondObject -> 0
-        GammaFirstObject -> 1
-        GammaFourthObject -> 2
-        GammaThirdObject -> 3
+        is GammaOutsideSealedClass.GammaSecondObject -> 0
+        is GammaFirstObject -> 1
+        is GammaFourthObject -> 2
+        is GammaThirdObject -> 3
     }
 
     public override fun nameOf(obj: GammaOutsideSealedClass): String = when (obj) {
-        GammaOutsideSealedClass.GammaSecondObject -> "GammaOutsideSealedClass_GammaSecondObject"
-        GammaFirstObject -> "GammaFirstObject"
-        GammaFourthObject -> "GammaFourthObject"
-        GammaThirdObject -> "GammaThirdObject"
+        is GammaOutsideSealedClass.GammaSecondObject -> "GammaOutsideSealedClass_GammaSecondObject"
+        is GammaFirstObject -> "GammaFirstObject"
+        is GammaFourthObject -> "GammaFourthObject"
+        is GammaThirdObject -> "GammaThirdObject"
     }
 
     public override fun valueOf(name: String): GammaOutsideSealedClass = when (name) {
@@ -341,11 +353,11 @@ public object GammaOutsideSealedClassSealedEnum : SealedEnum<GammaOutsideSealedC
 
     public override fun sealedObjectToEnum(obj: GammaOutsideSealedClass):
             GammaOutsideSealedClassEnum = when (obj) {
-        GammaOutsideSealedClass.GammaSecondObject ->
+        is GammaOutsideSealedClass.GammaSecondObject ->
                 GammaOutsideSealedClassEnum.GammaOutsideSealedClass_GammaSecondObject
-        GammaFirstObject -> GammaOutsideSealedClassEnum.GammaFirstObject
-        GammaFourthObject -> GammaOutsideSealedClassEnum.GammaFourthObject
-        GammaThirdObject -> GammaOutsideSealedClassEnum.GammaThirdObject
+        is GammaFirstObject -> GammaOutsideSealedClassEnum.GammaFirstObject
+        is GammaFourthObject -> GammaOutsideSealedClassEnum.GammaFourthObject
+        is GammaThirdObject -> GammaOutsideSealedClassEnum.GammaThirdObject
     }
 
     public override fun enumToSealedObject(`enum`: GammaOutsideSealedClassEnum):
@@ -410,6 +422,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -440,23 +453,26 @@ public val DeltaOutsideSealedClassEnum.sealedObject: DeltaOutsideSealedClass
 public object DeltaOutsideSealedClassSealedEnum : SealedEnum<DeltaOutsideSealedClass>,
         SealedEnumWithEnumProvider<DeltaOutsideSealedClass, DeltaOutsideSealedClassEnum>,
         EnumForSealedEnumProvider<DeltaOutsideSealedClass, DeltaOutsideSealedClassEnum> {
-    public override val values: List<DeltaOutsideSealedClass> = listOf(
-        DeltaOutsideSealedClass.DeltaObject,
-        DeltaObject
-    )
+    public override val values: List<DeltaOutsideSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            DeltaOutsideSealedClass.DeltaObject,
+            DeltaObject
+        )
+    }
 
 
     public override val enumClass: KClass<DeltaOutsideSealedClassEnum>
         get() = DeltaOutsideSealedClassEnum::class
 
     public override fun ordinalOf(obj: DeltaOutsideSealedClass): Int = when (obj) {
-        DeltaOutsideSealedClass.DeltaObject -> 0
-        DeltaObject -> 1
+        is DeltaOutsideSealedClass.DeltaObject -> 0
+        is DeltaObject -> 1
     }
 
     public override fun nameOf(obj: DeltaOutsideSealedClass): String = when (obj) {
-        DeltaOutsideSealedClass.DeltaObject -> "DeltaOutsideSealedClass_DeltaObject"
-        DeltaObject -> "DeltaObject"
+        is DeltaOutsideSealedClass.DeltaObject -> "DeltaOutsideSealedClass_DeltaObject"
+        is DeltaObject -> "DeltaObject"
     }
 
     public override fun valueOf(name: String): DeltaOutsideSealedClass = when (name) {
@@ -467,9 +483,9 @@ public object DeltaOutsideSealedClassSealedEnum : SealedEnum<DeltaOutsideSealedC
 
     public override fun sealedObjectToEnum(obj: DeltaOutsideSealedClass):
             DeltaOutsideSealedClassEnum = when (obj) {
-        DeltaOutsideSealedClass.DeltaObject ->
+        is DeltaOutsideSealedClass.DeltaObject ->
                 DeltaOutsideSealedClassEnum.DeltaOutsideSealedClass_DeltaObject
-        DeltaObject -> DeltaOutsideSealedClassEnum.DeltaObject
+        is DeltaObject -> DeltaOutsideSealedClassEnum.DeltaObject
     }
 
     public override fun enumToSealedObject(`enum`: DeltaOutsideSealedClassEnum):

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/SplitAcrossFilesSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/location/SplitAcrossFilesSealedClass.kt
@@ -17,6 +17,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -48,26 +49,29 @@ public val SplitAcrossFilesSealedClassEnum.sealedObject: SplitAcrossFilesSealedC
 public object SplitAcrossFilesSealedClassSealedEnum : SealedEnum<SplitAcrossFilesSealedClass>,
         SealedEnumWithEnumProvider<SplitAcrossFilesSealedClass, SplitAcrossFilesSealedClassEnum>,
         EnumForSealedEnumProvider<SplitAcrossFilesSealedClass, SplitAcrossFilesSealedClassEnum> {
-    public override val values: List<SplitAcrossFilesSealedClass> = listOf(
-        SplitAcrossFilesSubclassA,
-        SplitAcrossFilesSubclassB,
-        SplitAcrossFilesSubclassC
-    )
+    public override val values: List<SplitAcrossFilesSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            SplitAcrossFilesSubclassA,
+            SplitAcrossFilesSubclassB,
+            SplitAcrossFilesSubclassC
+        )
+    }
 
 
     public override val enumClass: KClass<SplitAcrossFilesSealedClassEnum>
         get() = SplitAcrossFilesSealedClassEnum::class
 
     public override fun ordinalOf(obj: SplitAcrossFilesSealedClass): Int = when (obj) {
-        SplitAcrossFilesSubclassA -> 0
-        SplitAcrossFilesSubclassB -> 1
-        SplitAcrossFilesSubclassC -> 2
+        is SplitAcrossFilesSubclassA -> 0
+        is SplitAcrossFilesSubclassB -> 1
+        is SplitAcrossFilesSubclassC -> 2
     }
 
     public override fun nameOf(obj: SplitAcrossFilesSealedClass): String = when (obj) {
-        SplitAcrossFilesSubclassA -> "SplitAcrossFilesSubclassA"
-        SplitAcrossFilesSubclassB -> "SplitAcrossFilesSubclassB"
-        SplitAcrossFilesSubclassC -> "SplitAcrossFilesSubclassC"
+        is SplitAcrossFilesSubclassA -> "SplitAcrossFilesSubclassA"
+        is SplitAcrossFilesSubclassB -> "SplitAcrossFilesSubclassB"
+        is SplitAcrossFilesSubclassC -> "SplitAcrossFilesSubclassC"
     }
 
     public override fun valueOf(name: String): SplitAcrossFilesSealedClass = when (name) {
@@ -79,9 +83,9 @@ public object SplitAcrossFilesSealedClassSealedEnum : SealedEnum<SplitAcrossFile
 
     public override fun sealedObjectToEnum(obj: SplitAcrossFilesSealedClass):
             SplitAcrossFilesSealedClassEnum = when (obj) {
-        SplitAcrossFilesSubclassA -> SplitAcrossFilesSealedClassEnum.SplitAcrossFilesSubclassA
-        SplitAcrossFilesSubclassB -> SplitAcrossFilesSealedClassEnum.SplitAcrossFilesSubclassB
-        SplitAcrossFilesSubclassC -> SplitAcrossFilesSealedClassEnum.SplitAcrossFilesSubclassC
+        is SplitAcrossFilesSubclassA -> SplitAcrossFilesSealedClassEnum.SplitAcrossFilesSubclassA
+        is SplitAcrossFilesSubclassB -> SplitAcrossFilesSealedClassEnum.SplitAcrossFilesSubclassB
+        is SplitAcrossFilesSubclassC -> SplitAcrossFilesSealedClassEnum.SplitAcrossFilesSubclassC
     }
 
     public override fun enumToSealedObject(`enum`: SplitAcrossFilesSealedClassEnum):

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/traversal/TraversalOrder.kt
@@ -69,6 +69,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -111,59 +112,61 @@ public val TreeLevelOrderEnum.sealedObject: Tree
 public object TreeLevelOrderSealedEnum : SealedEnum<Tree>,
         SealedEnumWithEnumProvider<Tree, TreeLevelOrderEnum>,
         EnumForSealedEnumProvider<Tree, TreeLevelOrderEnum> {
-    public override val values: List<Tree> = listOf(
-        Tree.A,
-        Tree.K,
-        Tree.T,
-        Tree.L.S,
-        Tree.B.C.D,
-        Tree.B.C.E,
-        Tree.B.C.J,
-        Tree.L.M.N,
-        Tree.L.M.O,
-        Tree.L.P.Q,
-        Tree.L.P.R,
-        Tree.B.C.F.G,
-        Tree.B.C.F.H,
-        Tree.B.C.F.I
-    )
+    public override val values: List<Tree> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Tree.A,
+            Tree.K,
+            Tree.T,
+            Tree.L.S,
+            Tree.B.C.D,
+            Tree.B.C.E,
+            Tree.B.C.J,
+            Tree.L.M.N,
+            Tree.L.M.O,
+            Tree.L.P.Q,
+            Tree.L.P.R,
+            Tree.B.C.F.G,
+            Tree.B.C.F.H,
+            Tree.B.C.F.I
+        )
+    }
 
 
     public override val enumClass: KClass<TreeLevelOrderEnum>
         get() = TreeLevelOrderEnum::class
 
     public override fun ordinalOf(obj: Tree): Int = when (obj) {
-        Tree.A -> 0
-        Tree.K -> 1
-        Tree.T -> 2
-        Tree.L.S -> 3
-        Tree.B.C.D -> 4
-        Tree.B.C.E -> 5
-        Tree.B.C.J -> 6
-        Tree.L.M.N -> 7
-        Tree.L.M.O -> 8
-        Tree.L.P.Q -> 9
-        Tree.L.P.R -> 10
-        Tree.B.C.F.G -> 11
-        Tree.B.C.F.H -> 12
-        Tree.B.C.F.I -> 13
+        is Tree.A -> 0
+        is Tree.K -> 1
+        is Tree.T -> 2
+        is Tree.L.S -> 3
+        is Tree.B.C.D -> 4
+        is Tree.B.C.E -> 5
+        is Tree.B.C.J -> 6
+        is Tree.L.M.N -> 7
+        is Tree.L.M.O -> 8
+        is Tree.L.P.Q -> 9
+        is Tree.L.P.R -> 10
+        is Tree.B.C.F.G -> 11
+        is Tree.B.C.F.H -> 12
+        is Tree.B.C.F.I -> 13
     }
 
     public override fun nameOf(obj: Tree): String = when (obj) {
-        Tree.A -> "Tree_A"
-        Tree.K -> "Tree_K"
-        Tree.T -> "Tree_T"
-        Tree.L.S -> "Tree_L_S"
-        Tree.B.C.D -> "Tree_B_C_D"
-        Tree.B.C.E -> "Tree_B_C_E"
-        Tree.B.C.J -> "Tree_B_C_J"
-        Tree.L.M.N -> "Tree_L_M_N"
-        Tree.L.M.O -> "Tree_L_M_O"
-        Tree.L.P.Q -> "Tree_L_P_Q"
-        Tree.L.P.R -> "Tree_L_P_R"
-        Tree.B.C.F.G -> "Tree_B_C_F_G"
-        Tree.B.C.F.H -> "Tree_B_C_F_H"
-        Tree.B.C.F.I -> "Tree_B_C_F_I"
+        is Tree.A -> "Tree_A"
+        is Tree.K -> "Tree_K"
+        is Tree.T -> "Tree_T"
+        is Tree.L.S -> "Tree_L_S"
+        is Tree.B.C.D -> "Tree_B_C_D"
+        is Tree.B.C.E -> "Tree_B_C_E"
+        is Tree.B.C.J -> "Tree_B_C_J"
+        is Tree.L.M.N -> "Tree_L_M_N"
+        is Tree.L.M.O -> "Tree_L_M_O"
+        is Tree.L.P.Q -> "Tree_L_P_Q"
+        is Tree.L.P.R -> "Tree_L_P_R"
+        is Tree.B.C.F.G -> "Tree_B_C_F_G"
+        is Tree.B.C.F.H -> "Tree_B_C_F_H"
+        is Tree.B.C.F.I -> "Tree_B_C_F_I"
     }
 
     public override fun valueOf(name: String): Tree = when (name) {
@@ -185,20 +188,20 @@ public object TreeLevelOrderSealedEnum : SealedEnum<Tree>,
     }
 
     public override fun sealedObjectToEnum(obj: Tree): TreeLevelOrderEnum = when (obj) {
-        Tree.A -> TreeLevelOrderEnum.Tree_A
-        Tree.K -> TreeLevelOrderEnum.Tree_K
-        Tree.T -> TreeLevelOrderEnum.Tree_T
-        Tree.L.S -> TreeLevelOrderEnum.Tree_L_S
-        Tree.B.C.D -> TreeLevelOrderEnum.Tree_B_C_D
-        Tree.B.C.E -> TreeLevelOrderEnum.Tree_B_C_E
-        Tree.B.C.J -> TreeLevelOrderEnum.Tree_B_C_J
-        Tree.L.M.N -> TreeLevelOrderEnum.Tree_L_M_N
-        Tree.L.M.O -> TreeLevelOrderEnum.Tree_L_M_O
-        Tree.L.P.Q -> TreeLevelOrderEnum.Tree_L_P_Q
-        Tree.L.P.R -> TreeLevelOrderEnum.Tree_L_P_R
-        Tree.B.C.F.G -> TreeLevelOrderEnum.Tree_B_C_F_G
-        Tree.B.C.F.H -> TreeLevelOrderEnum.Tree_B_C_F_H
-        Tree.B.C.F.I -> TreeLevelOrderEnum.Tree_B_C_F_I
+        is Tree.A -> TreeLevelOrderEnum.Tree_A
+        is Tree.K -> TreeLevelOrderEnum.Tree_K
+        is Tree.T -> TreeLevelOrderEnum.Tree_T
+        is Tree.L.S -> TreeLevelOrderEnum.Tree_L_S
+        is Tree.B.C.D -> TreeLevelOrderEnum.Tree_B_C_D
+        is Tree.B.C.E -> TreeLevelOrderEnum.Tree_B_C_E
+        is Tree.B.C.J -> TreeLevelOrderEnum.Tree_B_C_J
+        is Tree.L.M.N -> TreeLevelOrderEnum.Tree_L_M_N
+        is Tree.L.M.O -> TreeLevelOrderEnum.Tree_L_M_O
+        is Tree.L.P.Q -> TreeLevelOrderEnum.Tree_L_P_Q
+        is Tree.L.P.R -> TreeLevelOrderEnum.Tree_L_P_R
+        is Tree.B.C.F.G -> TreeLevelOrderEnum.Tree_B_C_F_G
+        is Tree.B.C.F.H -> TreeLevelOrderEnum.Tree_B_C_F_H
+        is Tree.B.C.F.I -> TreeLevelOrderEnum.Tree_B_C_F_I
     }
 
     public override fun enumToSealedObject(`enum`: TreeLevelOrderEnum): Tree = when (enum) {
@@ -289,59 +292,61 @@ public val TreePostOrderEnum.sealedObject: Tree
 public object TreePostOrderSealedEnum : SealedEnum<Tree>,
         SealedEnumWithEnumProvider<Tree, TreePostOrderEnum>,
         EnumForSealedEnumProvider<Tree, TreePostOrderEnum> {
-    public override val values: List<Tree> = listOf(
-        Tree.B.C.F.G,
-        Tree.B.C.F.H,
-        Tree.B.C.F.I,
-        Tree.B.C.D,
-        Tree.B.C.E,
-        Tree.B.C.J,
-        Tree.L.M.N,
-        Tree.L.M.O,
-        Tree.L.P.Q,
-        Tree.L.P.R,
-        Tree.L.S,
-        Tree.A,
-        Tree.K,
-        Tree.T
-    )
+    public override val values: List<Tree> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Tree.B.C.F.G,
+            Tree.B.C.F.H,
+            Tree.B.C.F.I,
+            Tree.B.C.D,
+            Tree.B.C.E,
+            Tree.B.C.J,
+            Tree.L.M.N,
+            Tree.L.M.O,
+            Tree.L.P.Q,
+            Tree.L.P.R,
+            Tree.L.S,
+            Tree.A,
+            Tree.K,
+            Tree.T
+        )
+    }
 
 
     public override val enumClass: KClass<TreePostOrderEnum>
         get() = TreePostOrderEnum::class
 
     public override fun ordinalOf(obj: Tree): Int = when (obj) {
-        Tree.B.C.F.G -> 0
-        Tree.B.C.F.H -> 1
-        Tree.B.C.F.I -> 2
-        Tree.B.C.D -> 3
-        Tree.B.C.E -> 4
-        Tree.B.C.J -> 5
-        Tree.L.M.N -> 6
-        Tree.L.M.O -> 7
-        Tree.L.P.Q -> 8
-        Tree.L.P.R -> 9
-        Tree.L.S -> 10
-        Tree.A -> 11
-        Tree.K -> 12
-        Tree.T -> 13
+        is Tree.B.C.F.G -> 0
+        is Tree.B.C.F.H -> 1
+        is Tree.B.C.F.I -> 2
+        is Tree.B.C.D -> 3
+        is Tree.B.C.E -> 4
+        is Tree.B.C.J -> 5
+        is Tree.L.M.N -> 6
+        is Tree.L.M.O -> 7
+        is Tree.L.P.Q -> 8
+        is Tree.L.P.R -> 9
+        is Tree.L.S -> 10
+        is Tree.A -> 11
+        is Tree.K -> 12
+        is Tree.T -> 13
     }
 
     public override fun nameOf(obj: Tree): String = when (obj) {
-        Tree.B.C.F.G -> "Tree_B_C_F_G"
-        Tree.B.C.F.H -> "Tree_B_C_F_H"
-        Tree.B.C.F.I -> "Tree_B_C_F_I"
-        Tree.B.C.D -> "Tree_B_C_D"
-        Tree.B.C.E -> "Tree_B_C_E"
-        Tree.B.C.J -> "Tree_B_C_J"
-        Tree.L.M.N -> "Tree_L_M_N"
-        Tree.L.M.O -> "Tree_L_M_O"
-        Tree.L.P.Q -> "Tree_L_P_Q"
-        Tree.L.P.R -> "Tree_L_P_R"
-        Tree.L.S -> "Tree_L_S"
-        Tree.A -> "Tree_A"
-        Tree.K -> "Tree_K"
-        Tree.T -> "Tree_T"
+        is Tree.B.C.F.G -> "Tree_B_C_F_G"
+        is Tree.B.C.F.H -> "Tree_B_C_F_H"
+        is Tree.B.C.F.I -> "Tree_B_C_F_I"
+        is Tree.B.C.D -> "Tree_B_C_D"
+        is Tree.B.C.E -> "Tree_B_C_E"
+        is Tree.B.C.J -> "Tree_B_C_J"
+        is Tree.L.M.N -> "Tree_L_M_N"
+        is Tree.L.M.O -> "Tree_L_M_O"
+        is Tree.L.P.Q -> "Tree_L_P_Q"
+        is Tree.L.P.R -> "Tree_L_P_R"
+        is Tree.L.S -> "Tree_L_S"
+        is Tree.A -> "Tree_A"
+        is Tree.K -> "Tree_K"
+        is Tree.T -> "Tree_T"
     }
 
     public override fun valueOf(name: String): Tree = when (name) {
@@ -363,20 +368,20 @@ public object TreePostOrderSealedEnum : SealedEnum<Tree>,
     }
 
     public override fun sealedObjectToEnum(obj: Tree): TreePostOrderEnum = when (obj) {
-        Tree.B.C.F.G -> TreePostOrderEnum.Tree_B_C_F_G
-        Tree.B.C.F.H -> TreePostOrderEnum.Tree_B_C_F_H
-        Tree.B.C.F.I -> TreePostOrderEnum.Tree_B_C_F_I
-        Tree.B.C.D -> TreePostOrderEnum.Tree_B_C_D
-        Tree.B.C.E -> TreePostOrderEnum.Tree_B_C_E
-        Tree.B.C.J -> TreePostOrderEnum.Tree_B_C_J
-        Tree.L.M.N -> TreePostOrderEnum.Tree_L_M_N
-        Tree.L.M.O -> TreePostOrderEnum.Tree_L_M_O
-        Tree.L.P.Q -> TreePostOrderEnum.Tree_L_P_Q
-        Tree.L.P.R -> TreePostOrderEnum.Tree_L_P_R
-        Tree.L.S -> TreePostOrderEnum.Tree_L_S
-        Tree.A -> TreePostOrderEnum.Tree_A
-        Tree.K -> TreePostOrderEnum.Tree_K
-        Tree.T -> TreePostOrderEnum.Tree_T
+        is Tree.B.C.F.G -> TreePostOrderEnum.Tree_B_C_F_G
+        is Tree.B.C.F.H -> TreePostOrderEnum.Tree_B_C_F_H
+        is Tree.B.C.F.I -> TreePostOrderEnum.Tree_B_C_F_I
+        is Tree.B.C.D -> TreePostOrderEnum.Tree_B_C_D
+        is Tree.B.C.E -> TreePostOrderEnum.Tree_B_C_E
+        is Tree.B.C.J -> TreePostOrderEnum.Tree_B_C_J
+        is Tree.L.M.N -> TreePostOrderEnum.Tree_L_M_N
+        is Tree.L.M.O -> TreePostOrderEnum.Tree_L_M_O
+        is Tree.L.P.Q -> TreePostOrderEnum.Tree_L_P_Q
+        is Tree.L.P.R -> TreePostOrderEnum.Tree_L_P_R
+        is Tree.L.S -> TreePostOrderEnum.Tree_L_S
+        is Tree.A -> TreePostOrderEnum.Tree_A
+        is Tree.K -> TreePostOrderEnum.Tree_K
+        is Tree.T -> TreePostOrderEnum.Tree_T
     }
 
     public override fun enumToSealedObject(`enum`: TreePostOrderEnum): Tree = when (enum) {
@@ -467,59 +472,61 @@ public val TreeInOrderEnum.sealedObject: Tree
 public object TreeInOrderSealedEnum : SealedEnum<Tree>,
         SealedEnumWithEnumProvider<Tree, TreeInOrderEnum>,
         EnumForSealedEnumProvider<Tree, TreeInOrderEnum> {
-    public override val values: List<Tree> = listOf(
-        Tree.A,
-        Tree.B.C.D,
-        Tree.B.C.E,
-        Tree.B.C.F.G,
-        Tree.B.C.F.H,
-        Tree.B.C.F.I,
-        Tree.B.C.J,
-        Tree.K,
-        Tree.L.M.N,
-        Tree.L.M.O,
-        Tree.L.P.Q,
-        Tree.L.P.R,
-        Tree.L.S,
-        Tree.T
-    )
+    public override val values: List<Tree> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Tree.A,
+            Tree.B.C.D,
+            Tree.B.C.E,
+            Tree.B.C.F.G,
+            Tree.B.C.F.H,
+            Tree.B.C.F.I,
+            Tree.B.C.J,
+            Tree.K,
+            Tree.L.M.N,
+            Tree.L.M.O,
+            Tree.L.P.Q,
+            Tree.L.P.R,
+            Tree.L.S,
+            Tree.T
+        )
+    }
 
 
     public override val enumClass: KClass<TreeInOrderEnum>
         get() = TreeInOrderEnum::class
 
     public override fun ordinalOf(obj: Tree): Int = when (obj) {
-        Tree.A -> 0
-        Tree.B.C.D -> 1
-        Tree.B.C.E -> 2
-        Tree.B.C.F.G -> 3
-        Tree.B.C.F.H -> 4
-        Tree.B.C.F.I -> 5
-        Tree.B.C.J -> 6
-        Tree.K -> 7
-        Tree.L.M.N -> 8
-        Tree.L.M.O -> 9
-        Tree.L.P.Q -> 10
-        Tree.L.P.R -> 11
-        Tree.L.S -> 12
-        Tree.T -> 13
+        is Tree.A -> 0
+        is Tree.B.C.D -> 1
+        is Tree.B.C.E -> 2
+        is Tree.B.C.F.G -> 3
+        is Tree.B.C.F.H -> 4
+        is Tree.B.C.F.I -> 5
+        is Tree.B.C.J -> 6
+        is Tree.K -> 7
+        is Tree.L.M.N -> 8
+        is Tree.L.M.O -> 9
+        is Tree.L.P.Q -> 10
+        is Tree.L.P.R -> 11
+        is Tree.L.S -> 12
+        is Tree.T -> 13
     }
 
     public override fun nameOf(obj: Tree): String = when (obj) {
-        Tree.A -> "Tree_A"
-        Tree.B.C.D -> "Tree_B_C_D"
-        Tree.B.C.E -> "Tree_B_C_E"
-        Tree.B.C.F.G -> "Tree_B_C_F_G"
-        Tree.B.C.F.H -> "Tree_B_C_F_H"
-        Tree.B.C.F.I -> "Tree_B_C_F_I"
-        Tree.B.C.J -> "Tree_B_C_J"
-        Tree.K -> "Tree_K"
-        Tree.L.M.N -> "Tree_L_M_N"
-        Tree.L.M.O -> "Tree_L_M_O"
-        Tree.L.P.Q -> "Tree_L_P_Q"
-        Tree.L.P.R -> "Tree_L_P_R"
-        Tree.L.S -> "Tree_L_S"
-        Tree.T -> "Tree_T"
+        is Tree.A -> "Tree_A"
+        is Tree.B.C.D -> "Tree_B_C_D"
+        is Tree.B.C.E -> "Tree_B_C_E"
+        is Tree.B.C.F.G -> "Tree_B_C_F_G"
+        is Tree.B.C.F.H -> "Tree_B_C_F_H"
+        is Tree.B.C.F.I -> "Tree_B_C_F_I"
+        is Tree.B.C.J -> "Tree_B_C_J"
+        is Tree.K -> "Tree_K"
+        is Tree.L.M.N -> "Tree_L_M_N"
+        is Tree.L.M.O -> "Tree_L_M_O"
+        is Tree.L.P.Q -> "Tree_L_P_Q"
+        is Tree.L.P.R -> "Tree_L_P_R"
+        is Tree.L.S -> "Tree_L_S"
+        is Tree.T -> "Tree_T"
     }
 
     public override fun valueOf(name: String): Tree = when (name) {
@@ -541,20 +548,20 @@ public object TreeInOrderSealedEnum : SealedEnum<Tree>,
     }
 
     public override fun sealedObjectToEnum(obj: Tree): TreeInOrderEnum = when (obj) {
-        Tree.A -> TreeInOrderEnum.Tree_A
-        Tree.B.C.D -> TreeInOrderEnum.Tree_B_C_D
-        Tree.B.C.E -> TreeInOrderEnum.Tree_B_C_E
-        Tree.B.C.F.G -> TreeInOrderEnum.Tree_B_C_F_G
-        Tree.B.C.F.H -> TreeInOrderEnum.Tree_B_C_F_H
-        Tree.B.C.F.I -> TreeInOrderEnum.Tree_B_C_F_I
-        Tree.B.C.J -> TreeInOrderEnum.Tree_B_C_J
-        Tree.K -> TreeInOrderEnum.Tree_K
-        Tree.L.M.N -> TreeInOrderEnum.Tree_L_M_N
-        Tree.L.M.O -> TreeInOrderEnum.Tree_L_M_O
-        Tree.L.P.Q -> TreeInOrderEnum.Tree_L_P_Q
-        Tree.L.P.R -> TreeInOrderEnum.Tree_L_P_R
-        Tree.L.S -> TreeInOrderEnum.Tree_L_S
-        Tree.T -> TreeInOrderEnum.Tree_T
+        is Tree.A -> TreeInOrderEnum.Tree_A
+        is Tree.B.C.D -> TreeInOrderEnum.Tree_B_C_D
+        is Tree.B.C.E -> TreeInOrderEnum.Tree_B_C_E
+        is Tree.B.C.F.G -> TreeInOrderEnum.Tree_B_C_F_G
+        is Tree.B.C.F.H -> TreeInOrderEnum.Tree_B_C_F_H
+        is Tree.B.C.F.I -> TreeInOrderEnum.Tree_B_C_F_I
+        is Tree.B.C.J -> TreeInOrderEnum.Tree_B_C_J
+        is Tree.K -> TreeInOrderEnum.Tree_K
+        is Tree.L.M.N -> TreeInOrderEnum.Tree_L_M_N
+        is Tree.L.M.O -> TreeInOrderEnum.Tree_L_M_O
+        is Tree.L.P.Q -> TreeInOrderEnum.Tree_L_P_Q
+        is Tree.L.P.R -> TreeInOrderEnum.Tree_L_P_R
+        is Tree.L.S -> TreeInOrderEnum.Tree_L_S
+        is Tree.T -> TreeInOrderEnum.Tree_T
     }
 
     public override fun enumToSealedObject(`enum`: TreeInOrderEnum): Tree = when (enum) {
@@ -644,59 +651,61 @@ public val TreePreOrderEnum.sealedObject: Tree
 public object TreePreOrderSealedEnum : SealedEnum<Tree>,
         SealedEnumWithEnumProvider<Tree, TreePreOrderEnum>,
         EnumForSealedEnumProvider<Tree, TreePreOrderEnum> {
-    public override val values: List<Tree> = listOf(
-        Tree.A,
-        Tree.K,
-        Tree.T,
-        Tree.B.C.D,
-        Tree.B.C.E,
-        Tree.B.C.J,
-        Tree.B.C.F.G,
-        Tree.B.C.F.H,
-        Tree.B.C.F.I,
-        Tree.L.S,
-        Tree.L.M.N,
-        Tree.L.M.O,
-        Tree.L.P.Q,
-        Tree.L.P.R
-    )
+    public override val values: List<Tree> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Tree.A,
+            Tree.K,
+            Tree.T,
+            Tree.B.C.D,
+            Tree.B.C.E,
+            Tree.B.C.J,
+            Tree.B.C.F.G,
+            Tree.B.C.F.H,
+            Tree.B.C.F.I,
+            Tree.L.S,
+            Tree.L.M.N,
+            Tree.L.M.O,
+            Tree.L.P.Q,
+            Tree.L.P.R
+        )
+    }
 
 
     public override val enumClass: KClass<TreePreOrderEnum>
         get() = TreePreOrderEnum::class
 
     public override fun ordinalOf(obj: Tree): Int = when (obj) {
-        Tree.A -> 0
-        Tree.K -> 1
-        Tree.T -> 2
-        Tree.B.C.D -> 3
-        Tree.B.C.E -> 4
-        Tree.B.C.J -> 5
-        Tree.B.C.F.G -> 6
-        Tree.B.C.F.H -> 7
-        Tree.B.C.F.I -> 8
-        Tree.L.S -> 9
-        Tree.L.M.N -> 10
-        Tree.L.M.O -> 11
-        Tree.L.P.Q -> 12
-        Tree.L.P.R -> 13
+        is Tree.A -> 0
+        is Tree.K -> 1
+        is Tree.T -> 2
+        is Tree.B.C.D -> 3
+        is Tree.B.C.E -> 4
+        is Tree.B.C.J -> 5
+        is Tree.B.C.F.G -> 6
+        is Tree.B.C.F.H -> 7
+        is Tree.B.C.F.I -> 8
+        is Tree.L.S -> 9
+        is Tree.L.M.N -> 10
+        is Tree.L.M.O -> 11
+        is Tree.L.P.Q -> 12
+        is Tree.L.P.R -> 13
     }
 
     public override fun nameOf(obj: Tree): String = when (obj) {
-        Tree.A -> "Tree_A"
-        Tree.K -> "Tree_K"
-        Tree.T -> "Tree_T"
-        Tree.B.C.D -> "Tree_B_C_D"
-        Tree.B.C.E -> "Tree_B_C_E"
-        Tree.B.C.J -> "Tree_B_C_J"
-        Tree.B.C.F.G -> "Tree_B_C_F_G"
-        Tree.B.C.F.H -> "Tree_B_C_F_H"
-        Tree.B.C.F.I -> "Tree_B_C_F_I"
-        Tree.L.S -> "Tree_L_S"
-        Tree.L.M.N -> "Tree_L_M_N"
-        Tree.L.M.O -> "Tree_L_M_O"
-        Tree.L.P.Q -> "Tree_L_P_Q"
-        Tree.L.P.R -> "Tree_L_P_R"
+        is Tree.A -> "Tree_A"
+        is Tree.K -> "Tree_K"
+        is Tree.T -> "Tree_T"
+        is Tree.B.C.D -> "Tree_B_C_D"
+        is Tree.B.C.E -> "Tree_B_C_E"
+        is Tree.B.C.J -> "Tree_B_C_J"
+        is Tree.B.C.F.G -> "Tree_B_C_F_G"
+        is Tree.B.C.F.H -> "Tree_B_C_F_H"
+        is Tree.B.C.F.I -> "Tree_B_C_F_I"
+        is Tree.L.S -> "Tree_L_S"
+        is Tree.L.M.N -> "Tree_L_M_N"
+        is Tree.L.M.O -> "Tree_L_M_O"
+        is Tree.L.P.Q -> "Tree_L_P_Q"
+        is Tree.L.P.R -> "Tree_L_P_R"
     }
 
     public override fun valueOf(name: String): Tree = when (name) {
@@ -718,20 +727,20 @@ public object TreePreOrderSealedEnum : SealedEnum<Tree>,
     }
 
     public override fun sealedObjectToEnum(obj: Tree): TreePreOrderEnum = when (obj) {
-        Tree.A -> TreePreOrderEnum.Tree_A
-        Tree.K -> TreePreOrderEnum.Tree_K
-        Tree.T -> TreePreOrderEnum.Tree_T
-        Tree.B.C.D -> TreePreOrderEnum.Tree_B_C_D
-        Tree.B.C.E -> TreePreOrderEnum.Tree_B_C_E
-        Tree.B.C.J -> TreePreOrderEnum.Tree_B_C_J
-        Tree.B.C.F.G -> TreePreOrderEnum.Tree_B_C_F_G
-        Tree.B.C.F.H -> TreePreOrderEnum.Tree_B_C_F_H
-        Tree.B.C.F.I -> TreePreOrderEnum.Tree_B_C_F_I
-        Tree.L.S -> TreePreOrderEnum.Tree_L_S
-        Tree.L.M.N -> TreePreOrderEnum.Tree_L_M_N
-        Tree.L.M.O -> TreePreOrderEnum.Tree_L_M_O
-        Tree.L.P.Q -> TreePreOrderEnum.Tree_L_P_Q
-        Tree.L.P.R -> TreePreOrderEnum.Tree_L_P_R
+        is Tree.A -> TreePreOrderEnum.Tree_A
+        is Tree.K -> TreePreOrderEnum.Tree_K
+        is Tree.T -> TreePreOrderEnum.Tree_T
+        is Tree.B.C.D -> TreePreOrderEnum.Tree_B_C_D
+        is Tree.B.C.E -> TreePreOrderEnum.Tree_B_C_E
+        is Tree.B.C.J -> TreePreOrderEnum.Tree_B_C_J
+        is Tree.B.C.F.G -> TreePreOrderEnum.Tree_B_C_F_G
+        is Tree.B.C.F.H -> TreePreOrderEnum.Tree_B_C_F_H
+        is Tree.B.C.F.I -> TreePreOrderEnum.Tree_B_C_F_I
+        is Tree.L.S -> TreePreOrderEnum.Tree_L_S
+        is Tree.L.M.N -> TreePreOrderEnum.Tree_L_M_N
+        is Tree.L.M.O -> TreePreOrderEnum.Tree_L_M_O
+        is Tree.L.P.Q -> TreePreOrderEnum.Tree_L_P_Q
+        is Tree.L.P.R -> TreePreOrderEnum.Tree_L_P_R
     }
 
     public override fun enumToSealedObject(`enum`: TreePreOrderEnum): Tree = when (enum) {

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnum.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/EnvironmentsSealedEnum.kt
@@ -43,6 +43,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -77,29 +78,32 @@ public val EnvironmentsEnum.sealedObject: Environments
 public object EnvironmentsSealedEnum : SealedEnum<Environments>,
         SealedEnumWithEnumProvider<Environments, EnvironmentsEnum>,
         EnumForSealedEnumProvider<Environments, EnvironmentsEnum> {
-    public override val values: List<Environments> = listOf(
-        Environments.Http.Livefront,
-        Environments.Http.Google,
-        Environments.Https.Livefront,
-        Environments.Https.Google
-    )
+    public override val values: List<Environments> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Environments.Http.Livefront,
+            Environments.Http.Google,
+            Environments.Https.Livefront,
+            Environments.Https.Google
+        )
+    }
 
 
     public override val enumClass: KClass<EnvironmentsEnum>
         get() = EnvironmentsEnum::class
 
     public override fun ordinalOf(obj: Environments): Int = when (obj) {
-        Environments.Http.Livefront -> 0
-        Environments.Http.Google -> 1
-        Environments.Https.Livefront -> 2
-        Environments.Https.Google -> 3
+        is Environments.Http.Livefront -> 0
+        is Environments.Http.Google -> 1
+        is Environments.Https.Livefront -> 2
+        is Environments.Https.Google -> 3
     }
 
     public override fun nameOf(obj: Environments): String = when (obj) {
-        Environments.Http.Livefront -> "Environments_Http_Livefront"
-        Environments.Http.Google -> "Environments_Http_Google"
-        Environments.Https.Livefront -> "Environments_Https_Livefront"
-        Environments.Https.Google -> "Environments_Https_Google"
+        is Environments.Http.Livefront -> "Environments_Http_Livefront"
+        is Environments.Http.Google -> "Environments_Http_Google"
+        is Environments.Https.Livefront -> "Environments_Https_Livefront"
+        is Environments.Https.Google -> "Environments_Https_Google"
     }
 
     public override fun valueOf(name: String): Environments = when (name) {
@@ -111,10 +115,10 @@ public object EnvironmentsSealedEnum : SealedEnum<Environments>,
     }
 
     public override fun sealedObjectToEnum(obj: Environments): EnvironmentsEnum = when (obj) {
-        Environments.Http.Livefront -> EnvironmentsEnum.Environments_Http_Livefront
-        Environments.Http.Google -> EnvironmentsEnum.Environments_Http_Google
-        Environments.Https.Livefront -> EnvironmentsEnum.Environments_Https_Livefront
-        Environments.Https.Google -> EnvironmentsEnum.Environments_Https_Google
+        is Environments.Http.Livefront -> EnvironmentsEnum.Environments_Http_Livefront
+        is Environments.Http.Google -> EnvironmentsEnum.Environments_Http_Google
+        is Environments.Https.Livefront -> EnvironmentsEnum.Environments_Https_Livefront
+        is Environments.Https.Google -> EnvironmentsEnum.Environments_Https_Google
     }
 
     public override fun enumToSealedObject(`enum`: EnvironmentsEnum): Environments = when (enum) {

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/Flag.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/Flag.kt
@@ -1,0 +1,123 @@
+package com.livefront.sealedenum.compilation.usecases
+
+import com.livefront.sealedenum.GenSealedEnum
+import org.intellij.lang.annotations.Language
+
+sealed class Flag {
+    val i: Int = 1 shl ordinal
+    object FirstFlag : Flag()
+
+    object SecondFlag : Flag()
+
+    @GenSealedEnum(generateEnum = true)
+    companion object
+}
+
+@Language("kotlin")
+val flagGenerated = """
+package com.livefront.sealedenum.compilation.usecases
+
+import com.livefront.sealedenum.EnumForSealedEnumProvider
+import com.livefront.sealedenum.SealedEnum
+import com.livefront.sealedenum.SealedEnumWithEnumProvider
+import kotlin.Int
+import kotlin.LazyThreadSafetyMode
+import kotlin.String
+import kotlin.collections.List
+import kotlin.reflect.KClass
+
+/**
+ * An isomorphic enum for the sealed class [Flag]
+ */
+public enum class FlagEnum() {
+    Flag_FirstFlag,
+    Flag_SecondFlag,
+}
+
+/**
+ * The isomorphic [FlagEnum] for [this].
+ */
+public val Flag.`enum`: FlagEnum
+    get() = FlagSealedEnum.sealedObjectToEnum(this)
+
+/**
+ * The isomorphic [Flag] for [this].
+ */
+public val FlagEnum.sealedObject: Flag
+    get() = FlagSealedEnum.enumToSealedObject(this)
+
+/**
+ * An implementation of [SealedEnum] for the sealed class [Flag]
+ */
+public object FlagSealedEnum : SealedEnum<Flag>, SealedEnumWithEnumProvider<Flag, FlagEnum>,
+        EnumForSealedEnumProvider<Flag, FlagEnum> {
+    public override val values: List<Flag> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            Flag.FirstFlag,
+            Flag.SecondFlag
+        )
+    }
+
+
+    public override val enumClass: KClass<FlagEnum>
+        get() = FlagEnum::class
+
+    public override fun ordinalOf(obj: Flag): Int = when (obj) {
+        is Flag.FirstFlag -> 0
+        is Flag.SecondFlag -> 1
+    }
+
+    public override fun nameOf(obj: Flag): String = when (obj) {
+        is Flag.FirstFlag -> "Flag_FirstFlag"
+        is Flag.SecondFlag -> "Flag_SecondFlag"
+    }
+
+    public override fun valueOf(name: String): Flag = when (name) {
+        "Flag_FirstFlag" -> Flag.FirstFlag
+        "Flag_SecondFlag" -> Flag.SecondFlag
+        else -> throw IllegalArgumentException(""${'"'}No sealed enum constant ${'$'}name""${'"'})
+    }
+
+    public override fun sealedObjectToEnum(obj: Flag): FlagEnum = when (obj) {
+        is Flag.FirstFlag -> FlagEnum.Flag_FirstFlag
+        is Flag.SecondFlag -> FlagEnum.Flag_SecondFlag
+    }
+
+    public override fun enumToSealedObject(`enum`: FlagEnum): Flag = when (enum) {
+        FlagEnum.Flag_FirstFlag -> Flag.FirstFlag
+        FlagEnum.Flag_SecondFlag -> Flag.SecondFlag
+    }
+}
+
+/**
+ * The index of [this] in the values list.
+ */
+public val Flag.ordinal: Int
+    get() = FlagSealedEnum.ordinalOf(this)
+
+/**
+ * The name of [this] for use with valueOf.
+ */
+public val Flag.name: String
+    get() = FlagSealedEnum.nameOf(this)
+
+/**
+ * A list of all [Flag] objects.
+ */
+public val Flag.Companion.values: List<Flag>
+    get() = FlagSealedEnum.values
+
+/**
+ * Returns an implementation of [SealedEnum] for the sealed class [Flag]
+ */
+public val Flag.Companion.sealedEnum: FlagSealedEnum
+    get() = FlagSealedEnum
+
+/**
+ * Returns the [Flag] object for the given [name].
+ *
+ * If the given name doesn't correspond to any [Flag], an [IllegalArgumentException] will be thrown.
+ */
+public fun Flag.Companion.valueOf(name: String): Flag = FlagSealedEnum.valueOf(name)
+
+""".trimIndent()

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/FlagTests.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/usecases/FlagTests.kt
@@ -1,0 +1,50 @@
+package com.livefront.sealedenum.compilation.usecases
+
+import com.livefront.sealedenum.testing.assertCompiles
+import com.livefront.sealedenum.testing.assertGeneratedFileMatches
+import com.livefront.sealedenum.testing.compile
+import com.livefront.sealedenum.testing.getCommonSourceFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FlagTests {
+    @Test
+    fun `two objects sealed class`() {
+        assertEquals(
+            listOf(Flag.FirstFlag, Flag.SecondFlag),
+            FlagSealedEnum.values
+        )
+    }
+
+    @Test
+    fun `two enums for sealed class`() {
+        assertEquals(
+            listOf(
+                FlagEnum.Flag_FirstFlag,
+                FlagEnum.Flag_SecondFlag
+            ),
+            enumValues<FlagEnum>().toList()
+        )
+    }
+
+    @Test
+    fun `two enums for sealed class with mapping`() {
+        assertEquals(
+            Flag.values.map(Flag::enum),
+            enumValues<FlagEnum>().toList()
+        )
+    }
+
+    @Test
+    fun `correct enum class`() {
+        assertEquals(FlagEnum::class, FlagSealedEnum.enumClass)
+    }
+
+    @Test
+    fun `compilation generates correct code`() {
+        val result = compile(getCommonSourceFile("compilation", "usecases", "Flag.kt"))
+
+        assertCompiles(result)
+        assertGeneratedFileMatches("Flag_SealedEnum.kt", flagGenerated, result)
+    }
+}

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/PrivateInterfaceSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/PrivateInterfaceSealedClass.kt
@@ -24,6 +24,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -54,23 +55,26 @@ public val PrivateInterfaceSealedClassEnum.sealedObject: PrivateInterfaceSealedC
 public object PrivateInterfaceSealedClassSealedEnum : SealedEnum<PrivateInterfaceSealedClass>,
         SealedEnumWithEnumProvider<PrivateInterfaceSealedClass, PrivateInterfaceSealedClassEnum>,
         EnumForSealedEnumProvider<PrivateInterfaceSealedClass, PrivateInterfaceSealedClassEnum> {
-    public override val values: List<PrivateInterfaceSealedClass> = listOf(
-        PrivateInterfaceSealedClass.FirstObject,
-        PrivateInterfaceSealedClass.SecondObject
-    )
+    public override val values: List<PrivateInterfaceSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            PrivateInterfaceSealedClass.FirstObject,
+            PrivateInterfaceSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<PrivateInterfaceSealedClassEnum>
         get() = PrivateInterfaceSealedClassEnum::class
 
     public override fun ordinalOf(obj: PrivateInterfaceSealedClass): Int = when (obj) {
-        PrivateInterfaceSealedClass.FirstObject -> 0
-        PrivateInterfaceSealedClass.SecondObject -> 1
+        is PrivateInterfaceSealedClass.FirstObject -> 0
+        is PrivateInterfaceSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: PrivateInterfaceSealedClass): String = when (obj) {
-        PrivateInterfaceSealedClass.FirstObject -> "PrivateInterfaceSealedClass_FirstObject"
-        PrivateInterfaceSealedClass.SecondObject -> "PrivateInterfaceSealedClass_SecondObject"
+        is PrivateInterfaceSealedClass.FirstObject -> "PrivateInterfaceSealedClass_FirstObject"
+        is PrivateInterfaceSealedClass.SecondObject -> "PrivateInterfaceSealedClass_SecondObject"
     }
 
     public override fun valueOf(name: String): PrivateInterfaceSealedClass = when (name) {
@@ -81,9 +85,9 @@ public object PrivateInterfaceSealedClassSealedEnum : SealedEnum<PrivateInterfac
 
     public override fun sealedObjectToEnum(obj: PrivateInterfaceSealedClass):
             PrivateInterfaceSealedClassEnum = when (obj) {
-        PrivateInterfaceSealedClass.FirstObject ->
+        is PrivateInterfaceSealedClass.FirstObject ->
                 PrivateInterfaceSealedClassEnum.PrivateInterfaceSealedClass_FirstObject
-        PrivateInterfaceSealedClass.SecondObject ->
+        is PrivateInterfaceSealedClass.SecondObject ->
                 PrivateInterfaceSealedClassEnum.PrivateInterfaceSealedClass_SecondObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClass.kt
@@ -29,6 +29,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -69,11 +70,13 @@ public object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEn
         SealedEnumWithEnumProvider<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass, ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>,
         EnumForSealedEnumProvider<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass, ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum>
         {
-    public override val values: List<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass> =
-            listOf(
-        ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject,
-        ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject
-    )
+    public override val values: List<ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass> by
+            lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject,
+            ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass:
@@ -82,15 +85,15 @@ public object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEn
 
     public override fun ordinalOf(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass):
             Int = when (obj) {
-        ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject -> 0
-        ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject -> 1
+        is ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject -> 0
+        is ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass):
             String = when (obj) {
-        ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject ->
+        is ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject ->
                 "ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_FirstObject"
-        ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject ->
+        is ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject ->
                 "ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_SecondObject"
     }
 
@@ -106,9 +109,9 @@ public object ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassSealedEn
     public override
             fun sealedObjectToEnum(obj: ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass):
             ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum = when (obj) {
-        ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject ->
+        is ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.FirstObject ->
                 ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum.ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_FirstObject
-        ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject ->
+        is ProtectedInterfaceOuterClass.ProtectedInterfaceSealedClass.SecondObject ->
                 ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClassEnum.ProtectedInterfaceOuterClass_ProtectedInterfaceSealedClass_SecondObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/ProtectedInterfaceSealedClassWithDifferentPackageBaseClass.kt
@@ -30,6 +30,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -80,10 +81,12 @@ public object
         {
     public override val values:
             List<ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass>
-            = listOf(
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject,
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.SecondObject
-    )
+            by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject,
+            ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass:
@@ -94,18 +97,22 @@ public object
     public override
             fun ordinalOf(obj: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass):
             Int = when (obj) {
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject ->
+        is
+                ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject ->
                 0
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.SecondObject ->
+        is
+                ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.SecondObject ->
                 1
     }
 
     public override
             fun nameOf(obj: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass):
             String = when (obj) {
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject ->
+        is
+                ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject ->
                 "ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_FirstObject"
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.SecondObject ->
+        is
+                ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.SecondObject ->
                 "ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_SecondObject"
     }
 
@@ -123,9 +130,11 @@ public object
             fun sealedObjectToEnum(obj: ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass):
             ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum
             = when (obj) {
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject ->
+        is
+                ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.FirstObject ->
                 ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum.ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_FirstObject
-        ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.SecondObject ->
+        is
+                ProtectedInterfaceOuterClassWithDifferentPackageBaseClass.ProtectedInterfaceSealedClass.SecondObject ->
                 ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClassEnum.ProtectedInterfaceOuterClassWithDifferentPackageBaseClass_ProtectedInterfaceSealedClass_SecondObject
     }
 

--- a/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
+++ b/processing-tests/common/test/kotlin/com/livefront/sealedenum/compilation/visibility/VisibilitySealedClass.kt
@@ -24,6 +24,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -55,26 +56,29 @@ public val InternalObjectsSealedClassEnum.sealedObject: InternalObjectsSealedCla
 public object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsSealedClass>,
         SealedEnumWithEnumProvider<InternalObjectsSealedClass, InternalObjectsSealedClassEnum>,
         EnumForSealedEnumProvider<InternalObjectsSealedClass, InternalObjectsSealedClassEnum> {
-    public override val values: List<InternalObjectsSealedClass> = listOf(
-        InternalObjectsSealedClass.FirstObject,
-        InternalObjectsSealedClass.SecondObject,
-        InternalObjectsSealedClass.InnerSealedClass.ThirdObject
-    )
+    public override val values: List<InternalObjectsSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            InternalObjectsSealedClass.FirstObject,
+            InternalObjectsSealedClass.SecondObject,
+            InternalObjectsSealedClass.InnerSealedClass.ThirdObject
+        )
+    }
 
 
     public override val enumClass: KClass<InternalObjectsSealedClassEnum>
         get() = InternalObjectsSealedClassEnum::class
 
     public override fun ordinalOf(obj: InternalObjectsSealedClass): Int = when (obj) {
-        InternalObjectsSealedClass.FirstObject -> 0
-        InternalObjectsSealedClass.SecondObject -> 1
-        InternalObjectsSealedClass.InnerSealedClass.ThirdObject -> 2
+        is InternalObjectsSealedClass.FirstObject -> 0
+        is InternalObjectsSealedClass.SecondObject -> 1
+        is InternalObjectsSealedClass.InnerSealedClass.ThirdObject -> 2
     }
 
     public override fun nameOf(obj: InternalObjectsSealedClass): String = when (obj) {
-        InternalObjectsSealedClass.FirstObject -> "InternalObjectsSealedClass_FirstObject"
-        InternalObjectsSealedClass.SecondObject -> "InternalObjectsSealedClass_SecondObject"
-        InternalObjectsSealedClass.InnerSealedClass.ThirdObject ->
+        is InternalObjectsSealedClass.FirstObject -> "InternalObjectsSealedClass_FirstObject"
+        is InternalObjectsSealedClass.SecondObject -> "InternalObjectsSealedClass_SecondObject"
+        is InternalObjectsSealedClass.InnerSealedClass.ThirdObject ->
                 "InternalObjectsSealedClass_InnerSealedClass_ThirdObject"
     }
 
@@ -88,11 +92,11 @@ public object InternalObjectsSealedClassSealedEnum : SealedEnum<InternalObjectsS
 
     public override fun sealedObjectToEnum(obj: InternalObjectsSealedClass):
             InternalObjectsSealedClassEnum = when (obj) {
-        InternalObjectsSealedClass.FirstObject ->
+        is InternalObjectsSealedClass.FirstObject ->
                 InternalObjectsSealedClassEnum.InternalObjectsSealedClass_FirstObject
-        InternalObjectsSealedClass.SecondObject ->
+        is InternalObjectsSealedClass.SecondObject ->
                 InternalObjectsSealedClassEnum.InternalObjectsSealedClass_SecondObject
-        InternalObjectsSealedClass.InnerSealedClass.ThirdObject ->
+        is InternalObjectsSealedClass.InnerSealedClass.ThirdObject ->
                 InternalObjectsSealedClassEnum.InternalObjectsSealedClass_InnerSealedClass_ThirdObject
     }
 
@@ -159,6 +163,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -189,23 +194,26 @@ internal val InternalSealedClassEnum.sealedObject: InternalSealedClass
 internal object InternalSealedClassSealedEnum : SealedEnum<InternalSealedClass>,
         SealedEnumWithEnumProvider<InternalSealedClass, InternalSealedClassEnum>,
         EnumForSealedEnumProvider<InternalSealedClass, InternalSealedClassEnum> {
-    public override val values: List<InternalSealedClass> = listOf(
-        InternalSealedClass.FirstObject,
-        InternalSealedClass.SecondObject
-    )
+    public override val values: List<InternalSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            InternalSealedClass.FirstObject,
+            InternalSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<InternalSealedClassEnum>
         get() = InternalSealedClassEnum::class
 
     public override fun ordinalOf(obj: InternalSealedClass): Int = when (obj) {
-        InternalSealedClass.FirstObject -> 0
-        InternalSealedClass.SecondObject -> 1
+        is InternalSealedClass.FirstObject -> 0
+        is InternalSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: InternalSealedClass): String = when (obj) {
-        InternalSealedClass.FirstObject -> "InternalSealedClass_FirstObject"
-        InternalSealedClass.SecondObject -> "InternalSealedClass_SecondObject"
+        is InternalSealedClass.FirstObject -> "InternalSealedClass_FirstObject"
+        is InternalSealedClass.SecondObject -> "InternalSealedClass_SecondObject"
     }
 
     public override fun valueOf(name: String): InternalSealedClass = when (name) {
@@ -216,8 +224,10 @@ internal object InternalSealedClassSealedEnum : SealedEnum<InternalSealedClass>,
 
     public override fun sealedObjectToEnum(obj: InternalSealedClass): InternalSealedClassEnum = when
             (obj) {
-        InternalSealedClass.FirstObject -> InternalSealedClassEnum.InternalSealedClass_FirstObject
-        InternalSealedClass.SecondObject -> InternalSealedClassEnum.InternalSealedClass_SecondObject
+        is InternalSealedClass.FirstObject ->
+                InternalSealedClassEnum.InternalSealedClass_FirstObject
+        is InternalSealedClass.SecondObject ->
+                InternalSealedClassEnum.InternalSealedClass_SecondObject
     }
 
     public override fun enumToSealedObject(`enum`: InternalSealedClassEnum): InternalSealedClass =
@@ -279,6 +289,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -309,23 +320,26 @@ public val InternalCompanionSealedClassEnum.sealedObject: InternalCompanionSeale
 public object InternalCompanionSealedClassSealedEnum : SealedEnum<InternalCompanionSealedClass>,
         SealedEnumWithEnumProvider<InternalCompanionSealedClass, InternalCompanionSealedClassEnum>,
         EnumForSealedEnumProvider<InternalCompanionSealedClass, InternalCompanionSealedClassEnum> {
-    public override val values: List<InternalCompanionSealedClass> = listOf(
-        InternalCompanionSealedClass.FirstObject,
-        InternalCompanionSealedClass.SecondObject
-    )
+    public override val values: List<InternalCompanionSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            InternalCompanionSealedClass.FirstObject,
+            InternalCompanionSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<InternalCompanionSealedClassEnum>
         get() = InternalCompanionSealedClassEnum::class
 
     public override fun ordinalOf(obj: InternalCompanionSealedClass): Int = when (obj) {
-        InternalCompanionSealedClass.FirstObject -> 0
-        InternalCompanionSealedClass.SecondObject -> 1
+        is InternalCompanionSealedClass.FirstObject -> 0
+        is InternalCompanionSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: InternalCompanionSealedClass): String = when (obj) {
-        InternalCompanionSealedClass.FirstObject -> "InternalCompanionSealedClass_FirstObject"
-        InternalCompanionSealedClass.SecondObject -> "InternalCompanionSealedClass_SecondObject"
+        is InternalCompanionSealedClass.FirstObject -> "InternalCompanionSealedClass_FirstObject"
+        is InternalCompanionSealedClass.SecondObject -> "InternalCompanionSealedClass_SecondObject"
     }
 
     public override fun valueOf(name: String): InternalCompanionSealedClass = when (name) {
@@ -336,9 +350,9 @@ public object InternalCompanionSealedClassSealedEnum : SealedEnum<InternalCompan
 
     public override fun sealedObjectToEnum(obj: InternalCompanionSealedClass):
             InternalCompanionSealedClassEnum = when (obj) {
-        InternalCompanionSealedClass.FirstObject ->
+        is InternalCompanionSealedClass.FirstObject ->
                 InternalCompanionSealedClassEnum.InternalCompanionSealedClass_FirstObject
-        InternalCompanionSealedClass.SecondObject ->
+        is InternalCompanionSealedClass.SecondObject ->
                 InternalCompanionSealedClassEnum.InternalCompanionSealedClass_SecondObject
     }
 
@@ -404,6 +418,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -437,24 +452,27 @@ internal object InternalSealedAndCompanionSealedClassSealedEnum :
         SealedEnumWithEnumProvider<InternalSealedAndCompanionSealedClass, InternalSealedAndCompanionSealedClassEnum>,
         EnumForSealedEnumProvider<InternalSealedAndCompanionSealedClass, InternalSealedAndCompanionSealedClassEnum>
         {
-    public override val values: List<InternalSealedAndCompanionSealedClass> = listOf(
-        InternalSealedAndCompanionSealedClass.FirstObject,
-        InternalSealedAndCompanionSealedClass.SecondObject
-    )
+    public override val values: List<InternalSealedAndCompanionSealedClass> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            InternalSealedAndCompanionSealedClass.FirstObject,
+            InternalSealedAndCompanionSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<InternalSealedAndCompanionSealedClassEnum>
         get() = InternalSealedAndCompanionSealedClassEnum::class
 
     public override fun ordinalOf(obj: InternalSealedAndCompanionSealedClass): Int = when (obj) {
-        InternalSealedAndCompanionSealedClass.FirstObject -> 0
-        InternalSealedAndCompanionSealedClass.SecondObject -> 1
+        is InternalSealedAndCompanionSealedClass.FirstObject -> 0
+        is InternalSealedAndCompanionSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: InternalSealedAndCompanionSealedClass): String = when (obj) {
-        InternalSealedAndCompanionSealedClass.FirstObject ->
+        is InternalSealedAndCompanionSealedClass.FirstObject ->
                 "InternalSealedAndCompanionSealedClass_FirstObject"
-        InternalSealedAndCompanionSealedClass.SecondObject ->
+        is InternalSealedAndCompanionSealedClass.SecondObject ->
                 "InternalSealedAndCompanionSealedClass_SecondObject"
     }
 
@@ -468,9 +486,9 @@ internal object InternalSealedAndCompanionSealedClassSealedEnum :
 
     public override fun sealedObjectToEnum(obj: InternalSealedAndCompanionSealedClass):
             InternalSealedAndCompanionSealedClassEnum = when (obj) {
-        InternalSealedAndCompanionSealedClass.FirstObject ->
+        is InternalSealedAndCompanionSealedClass.FirstObject ->
                 InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_FirstObject
-        InternalSealedAndCompanionSealedClass.SecondObject ->
+        is InternalSealedAndCompanionSealedClass.SecondObject ->
                 InternalSealedAndCompanionSealedClassEnum.InternalSealedAndCompanionSealedClass_SecondObject
     }
 

--- a/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameName.kt
+++ b/processing-tests/ksp-tests/src/test/kotlin/com/livefront/sealedenum/compilation/ksp/NestedObjectsWithSameName.kt
@@ -21,6 +21,7 @@ import com.livefront.sealedenum.EnumForSealedEnumProvider
 import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -53,8 +54,10 @@ public object NestedObjectsWithSameName_Companion_EmptySealedClassSealedEnum :
         SealedEnumWithEnumProvider<NestedObjectsWithSameName.Companion.EmptySealedClass, NestedObjectsWithSameName_Companion_EmptySealedClassEnum>,
         EnumForSealedEnumProvider<NestedObjectsWithSameName.Companion.EmptySealedClass, NestedObjectsWithSameName_Companion_EmptySealedClassEnum>
         {
-    public override val values: List<NestedObjectsWithSameName.Companion.EmptySealedClass> =
-            emptyList()
+    public override val values: List<NestedObjectsWithSameName.Companion.EmptySealedClass> by
+            lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        emptyList()
+    }
 
 
     public override val enumClass: KClass<NestedObjectsWithSameName_Companion_EmptySealedClassEnum>

--- a/processing-tests/processor-tests/src/test/kotlin/com/livefront/sealedenum/compilation/kitchensink/JavaBaseClasses.kt
+++ b/processing-tests/processor-tests/src/test/kotlin/com/livefront/sealedenum/compilation/kitchensink/JavaBaseClasses.kt
@@ -47,6 +47,7 @@ import com.livefront.sealedenum.SealedEnum
 import com.livefront.sealedenum.SealedEnumWithEnumProvider
 import kotlin.Double
 import kotlin.Int
+import kotlin.LazyThreadSafetyMode
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -85,23 +86,26 @@ public val JavaBaseClassesSealedClassEnum.sealedObject: JavaBaseClassesSealedCla
 public object JavaBaseClassesSealedClassSealedEnum : SealedEnum<JavaBaseClassesSealedClass<*>>,
         SealedEnumWithEnumProvider<JavaBaseClassesSealedClass<*>, JavaBaseClassesSealedClassEnum>,
         EnumForSealedEnumProvider<JavaBaseClassesSealedClass<*>, JavaBaseClassesSealedClassEnum> {
-    public override val values: List<JavaBaseClassesSealedClass<*>> = listOf(
-        JavaBaseClassesSealedClass.FirstObject,
-        JavaBaseClassesSealedClass.SecondObject
-    )
+    public override val values: List<JavaBaseClassesSealedClass<*>> by lazy(mode =
+            LazyThreadSafetyMode.PUBLICATION) {
+        listOf(
+            JavaBaseClassesSealedClass.FirstObject,
+            JavaBaseClassesSealedClass.SecondObject
+        )
+    }
 
 
     public override val enumClass: KClass<JavaBaseClassesSealedClassEnum>
         get() = JavaBaseClassesSealedClassEnum::class
 
     public override fun ordinalOf(obj: JavaBaseClassesSealedClass<*>): Int = when (obj) {
-        JavaBaseClassesSealedClass.FirstObject -> 0
-        JavaBaseClassesSealedClass.SecondObject -> 1
+        is JavaBaseClassesSealedClass.FirstObject -> 0
+        is JavaBaseClassesSealedClass.SecondObject -> 1
     }
 
     public override fun nameOf(obj: JavaBaseClassesSealedClass<*>): String = when (obj) {
-        JavaBaseClassesSealedClass.FirstObject -> "JavaBaseClassesSealedClass_FirstObject"
-        JavaBaseClassesSealedClass.SecondObject -> "JavaBaseClassesSealedClass_SecondObject"
+        is JavaBaseClassesSealedClass.FirstObject -> "JavaBaseClassesSealedClass_FirstObject"
+        is JavaBaseClassesSealedClass.SecondObject -> "JavaBaseClassesSealedClass_SecondObject"
     }
 
     public override fun valueOf(name: String): JavaBaseClassesSealedClass<*> = when (name) {
@@ -112,9 +116,9 @@ public object JavaBaseClassesSealedClassSealedEnum : SealedEnum<JavaBaseClassesS
 
     public override fun sealedObjectToEnum(obj: JavaBaseClassesSealedClass<*>):
             JavaBaseClassesSealedClassEnum = when (obj) {
-        JavaBaseClassesSealedClass.FirstObject ->
+        is JavaBaseClassesSealedClass.FirstObject ->
                 JavaBaseClassesSealedClassEnum.JavaBaseClassesSealedClass_FirstObject
-        JavaBaseClassesSealedClass.SecondObject ->
+        is JavaBaseClassesSealedClass.SecondObject ->
                 JavaBaseClassesSealedClassEnum.JavaBaseClassesSealedClass_SecondObject
     }
 

--- a/runtime/src/main/kotlin/com/livefront/sealedenum/GenSealedEnum.kt
+++ b/runtime/src/main/kotlin/com/livefront/sealedenum/GenSealedEnum.kt
@@ -17,19 +17,21 @@ package com.livefront.sealedenum
  * will generate the following object:
  * ```
  * object AlphaSealedEnum : SealedEnum<Alpha> {
- *     override val values: List<Alpha> = listOf(
- *         Alpha.Beta,
- *         Alpha.Gamma
- *     )
+ *     override val values: List<Alpha> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+ *         listOf(
+ *             Alpha.Beta,
+ *             Alpha.Gamma
+ *         )
+ *     }
  *
  *     override fun ordinalOf(obj: Alpha): Int = when (obj) {
- *         Alpha.Beta -> 0
- *         Alpha.Gamma -> 1
+ *         is Alpha.Beta -> 0
+ *         is Alpha.Gamma -> 1
  *     }
  *
  *     override fun nameOf(obj: AlphaSealedEnum): String = when (obj) {
- *         Alpha.Beta -> "Alpha_Beta"
- *         Alpha.Gamma -> "Alpha_Gamma"
+ *         is Alpha.Beta -> "Alpha_Beta"
+ *         is Alpha.Gamma -> "Alpha_Gamma"
  *     }
  *
  *     override fun valueOf(name: String): AlphaSealedEnum = when (name) {
@@ -89,22 +91,24 @@ package com.livefront.sealedenum
  * will generate two objects:
  * ```
  * object AlphaLevelOrderSealedEnum : SealedEnum<Alpha> {
- *     override val values: List<Alpha> = listOf(
- *         Alpha.Delta,
- *         Alpha.Beta.Gamma,
- *         Alpha.Epsilon.Zeta
- *     )
+ *     override val values: List<Alpha> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+ *         listOf(
+ *             Alpha.Delta,
+ *             Alpha.Beta.Gamma,
+ *             Alpha.Epsilon.Zeta
+ *         )
+ *     }
  *
  *     override fun ordinalOf(obj: Alpha): Int = when (obj) {
- *         Alpha.Delta -> 0
- *         Alpha.Beta.Gamma -> 1
- *         Alpha.Epsilon.Zeta -> 2
+ *         is Alpha.Delta -> 0
+ *         is Alpha.Beta.Gamma -> 1
+ *         is Alpha.Epsilon.Zeta -> 2
  *     }
  *
  *     override fun nameOf(obj: AlphaLevelOrderSealedEnum): String = when (obj) {
- *         Alpha.Delta -> "Alpha_Delta"
- *         Alpha.Beta.Gamma -> "Alpha_Beta_Gamma"
- *         Alpha.Epsilon.Zeta -> "Alpha_Epsilon_Zeta"
+ *         is Alpha.Delta -> "Alpha_Delta"
+ *         is Alpha.Beta.Gamma -> "Alpha_Beta_Gamma"
+ *         is Alpha.Epsilon.Zeta -> "Alpha_Epsilon_Zeta"
  *     }
  *
  *     override fun valueOf(name: String): AlphaLevelOrderSealedEnum = when (name) {
@@ -116,22 +120,24 @@ package com.livefront.sealedenum
  * }
  *
  * object AlphaInOrderSealedEnum : SealedEnum<Alpha> {
- *     override val values: List<Alpha> = listOf(
- *         Alpha.Beta.Gamma,
- *         Alpha.Delta,
- *         Alpha.Epsilon.Zeta
- *     )
+ *     override val values: List<Alpha> by lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+ *         listOf(
+ *             Alpha.Beta.Gamma,
+ *             Alpha.Delta,
+ *             Alpha.Epsilon.Zeta
+ *         )
+ *     }
  *
  *     override fun ordinalOf(obj: Alpha): Int = when (obj) {
- *         Alpha.Beta.Gamma -> 0
- *         Alpha.Delta -> 1
- *         Alpha.Epsilon.Zeta -> 2
+ *         is Alpha.Beta.Gamma -> 0
+ *         is Alpha.Delta -> 1
+ *         is Alpha.Epsilon.Zeta -> 2
  *     }
  *
  *     override fun nameOf(obj: AlphaInOrderSealedEnum): String = when (obj) {
- *         Alpha.Beta.Gamma -> "Alpha_Beta_Gamma"
- *         Alpha.Delta -> "Alpha_Delta"
- *         Alpha.Epsilon.Zeta -> "Alpha_Epsilon_Zeta"
+ *         is Alpha.Beta.Gamma -> "Alpha_Beta_Gamma"
+ *         is Alpha.Delta -> "Alpha_Delta"
+ *         is Alpha.Epsilon.Zeta -> "Alpha_Epsilon_Zeta"
  *     }
  *
  *     override fun valueOf(name: String): AlphaInOrderSealedEnum = when (name) {


### PR DESCRIPTION
See #129 for the cause of the crash. This changes the code gen to do comparison checks on sealed objects using `is` instead of using equality. Also adds relevant tests.